### PR TITLE
Add index to diagrams.user_id

### DIFF
--- a/alembic/versions/d2a5320cadc4_add_index_to_diagrams_user_id.py
+++ b/alembic/versions/d2a5320cadc4_add_index_to_diagrams_user_id.py
@@ -1,0 +1,24 @@
+"""add_index_to_diagrams_user_id
+
+Revision ID: d2a5320cadc4
+Revises: fea616e0fe7d
+Create Date: 2026-03-02 00:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d2a5320cadc4"
+down_revision = "fea616e0fe7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f("ix_diagrams_user_id"), "diagrams", ["user_id"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_diagrams_user_id"), table_name="diagrams")

--- a/btcopilot/pro/models/diagram.py
+++ b/btcopilot/pro/models/diagram.py
@@ -59,7 +59,7 @@ class Diagram(db.Model, ModelMixin):
 
     __tablename__ = "diagrams"
 
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     user = relationship(
         "User", primaryjoin="Diagram.user_id == User.id", back_populates="diagrams"
     )


### PR DESCRIPTION
## Summary
- Adds `index=True` to `Diagram.user_id` column, matching the existing pattern in `license.py`
- Includes Alembic migration to create the index on the `diagrams` table
- Improves query performance for user-scoped diagram lookups

## Test plan
- [ ] Run `alembic upgrade head` against a dev database to verify migration applies cleanly
- [ ] Verify `alembic downgrade -1` rolls back without errors
- [ ] Confirm `\d diagrams` in psql shows the new index on `user_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)