### PR TITLE
Fix CI: mark test_update as e2e to skip without API key

### DIFF
--- a/btcopilot/tests/training/test_pdp.py
+++ b/btcopilot/tests/training/test_pdp.py
@@ -19,6 +19,7 @@ from btcopilot.personal.models import Discussion, Statement, Speaker, SpeakerTyp
 _log = logging.getLogger(__name__)
 
 
+@pytest.mark.e2e
 def test_update(test_user):
 
     discussion = Discussion(


### PR DESCRIPTION
## Summary
- Added `@pytest.mark.e2e` to `test_update` in `tests/training/test_pdp.py`
- This test calls `pdp.update()` which initializes Gemini and fails with `KeyError: 'GOOGLE_GEMINI_API_KEY'` in CI
- The e2e marker (already registered in conftest.py) causes it to be skipped unless `--e2e` is passed

## Test plan
- [x] Ran `uv run pytest btcopilot/tests/training/test_pdp.py -v` — test_update is SKIPPED, 7 other tests PASSED
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)