### PR TITLE
Add index to sessions.user_id

### DIFF
--- a/alembic/versions/e5f6a7b8c9d0_add_index_to_sessions_user_id.py
+++ b/alembic/versions/e5f6a7b8c9d0_add_index_to_sessions_user_id.py
@@ -1,0 +1,23 @@
+"""add_index_to_sessions_user_id
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-03-02 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e5f6a7b8c9d0"
+down_revision = "d4e5f6a7b8c9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f("ix_sessions_user_id"), "sessions", ["user_id"], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_sessions_user_id"), table_name="sessions")

--- a/btcopilot/pro/models/session.py
+++ b/btcopilot/pro/models/session.py
@@ -14,7 +14,7 @@ _log = logging.getLogger(__name__)
 class Session(db.Model, ModelMixin):
     __tablename__ = "sessions"
 
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     user = relationship("User", back_populates="sessions")
 
     token = Column(String(64), nullable=False, unique=True)


### PR DESCRIPTION
## Summary
- Adds `index=True` to `Session.user_id` column in `btcopilot/pro/models/session.py` for faster user-based session lookups
- Includes Alembic migration (`e5f6a7b8c9d0`) to create the `ix_sessions_user_id` index on the `sessions` table

## Test plan
- [ ] Run `uv run alembic upgrade head` against dev database to verify migration applies cleanly
- [ ] Verify `ix_sessions_user_id` index exists on `sessions` table after migration
- [ ] Run `uv run alembic downgrade -1` to verify rollback drops the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)