### PR TITLE
Remove duplicate chromadb dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ app = [
     "bcrypt",
     "celery==5.5.3",
     "redis",
-    "chromadb",
     "click",
     "ddtrace",
     "gunicorn",


### PR DESCRIPTION
## Summary
- Removed duplicate `chromadb` entry from `[project.optional-dependencies] app` in `pyproject.toml`
- `chromadb` appeared twice: once near the top of the list (between `celery` and `click`) and once in the training section (before `langchain-chroma`)
- Kept the training-section occurrence since it's grouped with related langchain dependencies
- Verified `uv lock --check` passes

## Test plan
- [x] `chromadb` appears exactly once in pyproject.toml
- [x] `uv lock --check` validates the lockfile is still consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)