### PR TITLE
Add database indexes to personal models FK columns

### DIFF
--- a/alembic/versions/f1a2b3c4d5e6_add_indexes_to_personal_models_fks.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_indexes_to_personal_models_fks.py
@@ -1,0 +1,44 @@
+"""add_indexes_to_personal_models_fks
+
+Revision ID: f1a2b3c4d5e6
+Revises: e5f6a7b8c9d0
+Create Date: 2026-03-02 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_discussions_user_id"), "discussions", ["user_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_discussions_diagram_id"), "discussions", ["diagram_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_statements_discussion_id"),
+        "statements",
+        ["discussion_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_statements_speaker_id"), "statements", ["speaker_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_speakers_discussion_id"), "speakers", ["discussion_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("ix_speakers_discussion_id"), table_name="speakers")
+    op.drop_index(op.f("ix_statements_speaker_id"), table_name="statements")
+    op.drop_index(op.f("ix_statements_discussion_id"), table_name="statements")
+    op.drop_index(op.f("ix_discussions_diagram_id"), table_name="discussions")
+    op.drop_index(op.f("ix_discussions_user_id"), table_name="discussions")

--- a/btcopilot/personal/models/discussion.py
+++ b/btcopilot/personal/models/discussion.py
@@ -21,8 +21,8 @@ class Discussion(db.Model, ModelMixin):
 
     __tablename__ = "discussions"
 
-    user_id = Column(Integer, db.ForeignKey("users.id"))
-    diagram_id = Column(Integer, db.ForeignKey("diagrams.id"))
+    user_id = Column(Integer, db.ForeignKey("users.id"), index=True)
+    diagram_id = Column(Integer, db.ForeignKey("diagrams.id"), index=True)
     summary = Column(Text)
     discussion_date = Column(
         Date,

--- a/btcopilot/personal/models/speaker.py
+++ b/btcopilot/personal/models/speaker.py
@@ -15,7 +15,7 @@ class Speaker(db.Model, ModelMixin):
 
     __tablename__ = "speakers"
 
-    discussion_id = Column(Integer, ForeignKey("discussions.id"))
+    discussion_id = Column(Integer, ForeignKey("discussions.id"), index=True)
     person_id = Column(
         Integer
     )  # References a Person in personal.database.Database JSON data

--- a/btcopilot/personal/models/statement.py
+++ b/btcopilot/personal/models/statement.py
@@ -19,8 +19,8 @@ class Statement(db.Model, ModelMixin):
     __tablename__ = "statements"
 
     text = Column(Text)
-    discussion_id = Column(Integer, ForeignKey("discussions.id"))
-    speaker_id = Column(Integer, ForeignKey("speakers.id"))
+    discussion_id = Column(Integer, ForeignKey("discussions.id"), index=True)
+    speaker_id = Column(Integer, ForeignKey("speakers.id"), index=True)
     pdp_deltas = Column(JSON)
     custom_prompts = Column(JSON)  # Store custom prompts used for this statement
     order = Column(Integer)  # Order within discussion for reliable sorting


### PR DESCRIPTION
## Summary
- Add `index=True` to 5 foreign key columns across personal app models (`discussions.user_id`, `discussions.diagram_id`, `statements.discussion_id`, `statements.speaker_id`, `speakers.discussion_id`) to prevent full table scans on joins and filters
- Include Alembic migration with 5 `CreateIndex` operations

Closes patrickkidd/theapp#15

## Test plan
- [ ] Verify migration applies cleanly: `uv run alembic upgrade head`
- [ ] Verify indexes exist in DB: `\d discussions`, `\d statements`, `\d speakers`
- [ ] Verify downgrade works: `uv run alembic downgrade -1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)