### PR TITLE
Remove redundant merge() calls in User.set_free_diagram()

### DIFF
--- a/btcopilot/pro/models/user.py
+++ b/btcopilot/pro/models/user.py
@@ -149,9 +149,9 @@ class User(db.Model, ModelMixin):
             diagram = Diagram(user_id=self.id, name="Free Diagram", data=bdata)
             db_session = inspect(self).session
             db_session.add(diagram)
-            db_session.merge(diagram)
+            db_session.flush()
             self.update(free_diagram_id=diagram.id)
-            db_session.merge(diagram)
+            db_session.flush()
             db_session.refresh(self)
         if updated_at is not None:
             _updated_at = updated_at


### PR DESCRIPTION
## Summary
- Replace two redundant `db_session.merge(diagram)` calls with `db_session.flush()` in `User.set_free_diagram()`
- After `db_session.add(diagram)`, the diagram is already in the session — `merge()` is unnecessary and wastes a round-trip
- First `flush()` ensures `diagram.id` is assigned (needed for the FK update), second `flush()` persists the FK before `refresh()` reloads relationships

## Test plan
- [x] All 4 free_diagram tests pass (`test_users_get_free_diagram_none`, `test_users_get_free_diagram_data`, `test_users_update_free_diagram_data`, `test_import_discussion_to_current_user_free_diagram`)
- [x] Full pro test suite passes (103 passed, 11 skipped)

Closes patrickkidd/theapp#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)