### PR TITLE
Remove commented-out dead code from User model

### DIFF
--- a/btcopilot/pro/models/user.py
+++ b/btcopilot/pro/models/user.py
@@ -68,35 +68,8 @@ class User(db.Model, ModelMixin):
         if not "status" in kwargs:
             self.status = "pending"
 
-        # self.is_authenticated = False
-        # self.is_active = True
-        # self.is_anonymous = False
-
     def __str__(self):
         return "<User id: %i, %s, %s>" % (self.id, self.full_name(), self.username)
-
-    # Flask-Login
-    # def get_id(self) -> str:
-    #     """Flask-Login"""
-    #     return str(self.id)
-
-    # @staticmethod
-    # def generate_reset_password_code(email):
-    #     serializer = URLSafeTimedSerializer(app.config['SECRET_KEY'])
-    #     return serializer.dumps(email, salt=app.config['SECURITY_PASSWORD_SALT'])
-
-    # @staticmethod
-    # def confirm_reset_password_code(tokecode, expiration=3600):
-    #     serializer = URLSafeTimedSerializer(app.config['SECRET_KEY'])
-    #     try:
-    #         email = serializer.loads(
-    #             code,
-    #             salt=app.config['SECURITY_PASSWORD_SALT'],
-    #             max_age=expiration
-    #         )
-    #     except:
-    #         return False
-    #     return email
 
     def as_dict(self, update=None, include=None, exclude=None, only=None):
         if not exclude:


### PR DESCRIPTION
## Summary
- Removed 3 blocks of commented-out dead code from `btcopilot/pro/models/user.py`:
  - Commented-out `is_authenticated`/`is_active`/`is_anonymous` assignments in `__init__`
  - Commented-out Flask-Login `get_id` method
  - Commented-out `generate_reset_password_code` and `confirm_reset_password_code` static methods
- 27 lines of dead code removed, no behavioral changes

## Test plan
- [x] All 103 pro tests pass (`uv run pytest btcopilot/tests/pro/ -x -q`)

Closes patrickkidd/theapp#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)