### PR TITLE
Remove unused conversation_id param from Engine.ask()

### DIFF
--- a/btcopilot/pro/copilot/engine.py
+++ b/btcopilot/pro/copilot/engine.py
@@ -162,9 +162,7 @@ class Engine:
 
         return ChatPromptTemplate.from_template(kind)
 
-    def ask(
-        self, question: str, events: list[Event] = None, conversation_id: str = None
-    ) -> Response:
+    def ask(self, question: str, events: list[Event] = None) -> Response:
 
         _log.info(f"Query with question: {question}")
 

--- a/btcopilot/pro/routes.py
+++ b/btcopilot/pro/routes.py
@@ -903,7 +903,7 @@ def copilot_chat(conversation_id: int = None):
         for x in args.get("events", [])
     ]
 
-    response = current_app.engine.ask(args["question"], events, conversation_id)
+    response = current_app.engine.ask(args["question"], events)
     return pickle.dumps(
         {
             "conversation_id": conversation_id,


### PR DESCRIPTION
## Summary
- Remove unused `conversation_id` parameter from `Engine.ask()` method signature
- Update the `copilot_chat` route caller to stop passing the argument
- Addresses Gemini code review feedback on PR #44

## Test plan
- [x] `uv run pytest btcopilot/tests/pro/copilot/test_engine.py -x -q` passes (2/2)
- [x] Grep confirms no active `conversation_id` references remain in `pro/copilot/` (only commented-out dead code)
- [x] Route still returns `conversation_id` in response payload (unchanged API contract)

Closes patrickkidd/theapp#38

🤖 Generated with [Claude Code](https://claude.com/claude-code)