### PR TITLE
T7-12: Add auto-detect cluster backend tests

### DIFF
--- a/btcopilot/tests/personal/test_clusters.py
+++ b/btcopilot/tests/personal/test_clusters.py
@@ -160,3 +160,238 @@ def test_detect_clusters_route_success(subscriber):
     assert "cacheKey" in data
     assert len(data["clusters"]) == 1
     assert data["clusters"][0]["title"] == "Anxiety Cascade"
+
+
+def test_detect_clusters_idempotent():
+    """Calling detect_clusters with the same events produces the same cache key (T7-12)."""
+    events = [
+        Event(id=1, kind=EventKind.Shift, dateTime="2024-01-15", symptom="up"),
+        Event(id=2, kind=EventKind.Shift, dateTime="2024-01-16", anxiety="up"),
+    ]
+
+    mock_response = MagicMock()
+    mock_response.clusters = [
+        Cluster(
+            id="c1",
+            title="Test Cluster",
+            summary="Test",
+            eventIds=[1, 2],
+            pattern=ClusterPattern.AnxietyCascade,
+        )
+    ]
+
+    with patch(
+        "btcopilot.personal.clusters.gemini_structured_sync", return_value=mock_response
+    ):
+        result1 = detect_clusters(events)
+        result2 = detect_clusters(events)
+
+    assert result1.cacheKey == result2.cacheKey
+
+
+def test_detect_clusters_handles_single_event():
+    """Single event produces valid cluster result (T7-12 edge case)."""
+    events = [
+        Event(id=1, kind=EventKind.Shift, dateTime="2024-01-15", description="Solo event"),
+    ]
+
+    mock_response = MagicMock()
+    mock_response.clusters = []
+
+    with patch(
+        "btcopilot.personal.clusters.gemini_structured_sync", return_value=mock_response
+    ):
+        result = detect_clusters(events)
+
+    assert isinstance(result, ClusterResult)
+    assert result.clusters == []
+    assert result.cacheKey is not None
+
+
+def test_auto_detect_clusters_after_pdp_accept(subscriber):
+    """T7-12: After PDP accept (events committed to diagram), clusters are auto-detected
+    via the /clusters endpoint without manual intervention.
+
+    This simulates the full flow:
+    1. Import text → PDP events created
+    2. Accept PDP → events committed to diagram
+    3. Auto-detect clusters (client calls /clusters with committed events)
+    4. Clusters returned and up-to-date
+    """
+    from mock import AsyncMock
+    from btcopilot.schema import PDP, PDPDeltas, Person
+
+    diagram = subscriber.user.free_diagram
+
+    # Step 1: Import text to create PDP events
+    events = [
+        Event(
+            id=-1,
+            kind=EventKind.Shift,
+            dateTime="2024-06-01",
+            description="Anxiety spike after family call",
+            anxiety="up",
+            person=-10,
+        ),
+        Event(
+            id=-2,
+            kind=EventKind.Shift,
+            dateTime="2024-06-02",
+            description="Sleep disrupted, racing thoughts",
+            symptom="up",
+            person=-10,
+        ),
+        Event(
+            id=-3,
+            kind=EventKind.Shift,
+            dateTime="2024-06-03",
+            description="Conflict with spouse about schedule",
+            relationship="conflict",
+            person=-10,
+        ),
+        Event(
+            id=-4,
+            kind=EventKind.Shift,
+            dateTime="2024-06-10",
+            description="Processing session with therapist",
+            functioning="up",
+            person=-10,
+        ),
+        Event(
+            id=-5,
+            kind=EventKind.Shift,
+            dateTime="2024-06-11",
+            description="Good conversation with spouse, reconnecting",
+            relationship="toward",
+            person=-10,
+        ),
+        Event(
+            id=-6,
+            kind=EventKind.Shift,
+            dateTime="2024-07-01",
+            description="Work deadline stress",
+            anxiety="up",
+            person=-10,
+        ),
+        Event(
+            id=-7,
+            kind=EventKind.Shift,
+            dateTime="2024-07-02",
+            description="Headaches started",
+            symptom="up",
+            person=-10,
+        ),
+        Event(
+            id=-8,
+            kind=EventKind.Shift,
+            dateTime="2024-07-03",
+            description="Snapped at coworker",
+            relationship="conflict",
+            person=-10,
+        ),
+        Event(
+            id=-9,
+            kind=EventKind.Shift,
+            dateTime="2024-07-15",
+            description="Went for long walk, felt calmer",
+            anxiety="down",
+            person=-10,
+        ),
+        Event(
+            id=-10,
+            kind=EventKind.Shift,
+            dateTime="2024-07-16",
+            description="Talked it out with manager",
+            relationship="toward",
+            person=-10,
+        ),
+    ]
+    mock_pdp = PDP(
+        people=[Person(id=-10, name="Self", confidence=0.9)],
+        events=events,
+    )
+    mock_deltas = PDPDeltas(
+        people=[Person(id=-10, name="Self", confidence=0.9)],
+        events=events,
+    )
+
+    with patch(
+        "btcopilot.pdp.import_text",
+        AsyncMock(return_value=(mock_pdp, mock_deltas)),
+    ):
+        response = subscriber.post(
+            f"/personal/diagrams/{diagram.id}/import-text",
+            json={"text": "Journal with 10 events spanning June-July 2024."},
+        )
+
+    assert response.status_code == 200
+    pdp_data = response.get_json()["pdp"]
+    assert len(pdp_data["events"]) == 10
+
+    # Step 2: Simulate accept — events are now "committed" in diagram
+    # (In real app, client calls commit_pdp_items then diagram.save)
+
+    # Step 3: Auto-detect clusters (what the client does after PDP accept)
+    committed_events = [asdict(e) for e in events]
+    # Simulate committed events with positive IDs (as they would be after commit)
+    for i, e in enumerate(committed_events):
+        e["id"] = i + 1  # Positive IDs after commit
+
+    mock_cluster_response = MagicMock()
+    mock_cluster_response.clusters = [
+        Cluster(
+            id="c1",
+            title="Family Anxiety Cascade",
+            summary="Family call triggers anxiety, sleep disruption, and spousal conflict",
+            eventIds=[1, 2, 3, 4, 5],
+            pattern=ClusterPattern.AnxietyCascade,
+            dominantVariable="A",
+        ),
+        Cluster(
+            id="c2",
+            title="Work Stress Episode",
+            summary="Work deadline triggers physical symptoms and interpersonal conflict",
+            eventIds=[6, 7, 8, 9, 10],
+            pattern=ClusterPattern.WorkFamilySpillover,
+            dominantVariable="A",
+        ),
+    ]
+
+    with patch(
+        "btcopilot.personal.clusters.gemini_structured_sync",
+        return_value=mock_cluster_response,
+    ):
+        response = subscriber.post(
+            f"/personal/diagrams/{diagram.id}/clusters",
+            json={"events": committed_events},
+        )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "clusters" in data
+    assert "cacheKey" in data
+    assert len(data["clusters"]) == 2
+
+    # Verify cluster content
+    cluster_titles = {c["title"] for c in data["clusters"]}
+    assert "Family Anxiety Cascade" in cluster_titles
+    assert "Work Stress Episode" in cluster_titles
+
+    # Verify all 10 events are covered by the two clusters
+    all_cluster_event_ids = set()
+    for c in data["clusters"]:
+        all_cluster_event_ids.update(c["eventIds"])
+    assert all_cluster_event_ids == {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+    # Verify cache key is stable (idempotency)
+    first_cache_key = data["cacheKey"]
+    with patch(
+        "btcopilot.personal.clusters.gemini_structured_sync",
+        return_value=mock_cluster_response,
+    ):
+        response2 = subscriber.post(
+            f"/personal/diagrams/{diagram.id}/clusters",
+            json={"events": committed_events},
+        )
+
+    assert response2.get_json()["cacheKey"] == first_cache_key


### PR DESCRIPTION
## Summary
- Cherry-pick T7-12 test coverage from closed PR #32 (branch `feature/t7-12-auto-detect-clusters`)
- Adds idempotency test, single-event edge case test, and full acceptance test simulating PDP accept → cluster detection flow with 10 events
- All 12 cluster tests pass locally

## Test plan
- [x] `uv run pytest btcopilot/tests/personal/test_clusters.py -x -q` — 12 passed

Closes patrickkidd/theapp#39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #31