### PR TITLE
T7-7: Add cumulative F1 validation script for T7-5 discussions (Closes #27)

### DIFF
--- a/btcopilot/training/validate_t7_f1.py
+++ b/btcopilot/training/validate_t7_f1.py
@@ -199,7 +199,7 @@ def main():
             print(f"Running cumulative F1 on discussions: {ids}\n")
             results = validate_discussions(ids, detailed=args.detailed)
             if not results:
-                print("No valid results. Check that discussions exist and have approved GT.")
+                print("No valid results. Check that discussions exist and have approved GT. Please ensure that the discussion IDs are correct and that approved ground truth data is available.")
                 sys.exit(1)
             all_pass = print_report(results, detailed=args.detailed)
             sys.exit(0 if all_pass else 1)


### PR DESCRIPTION
Closes #27

## Summary

- Adds `btcopilot/training/validate_t7_f1.py` — a standalone script that runs `calculate_cumulative_f1()` on T7-5 synthetic discussions (IDs 50, 51, 52) and validates against target metrics
- Target: People F1 > 0.7, Events F1 > 0.3
- Reports per-discussion TP/FP/FN breakdown, aggregate averages, failure patterns, and zero pair-bonds detection
