### PR TITLE
Add Pattern Intelligence feature for cross-generational insights

### DIFF
--- a/btcopilot/personal/insights.py
+++ b/btcopilot/personal/insights.py
@@ -1,0 +1,85 @@
+"""
+Pattern Intelligence: generates natural-language insights about cross-generational
+family patterns from extracted PDP data.
+"""
+
+import logging
+import re
+
+from btcopilot.llmutil import gemini_text_sync
+from btcopilot.schema import PDP, asdict
+
+_log = logging.getLogger(__name__)
+
+INSIGHTS_PROMPT = """\
+You are a family systems analyst trained in Bowen theory. Given this family data, \
+identify 2-3 cross-generational patterns. Focus on:
+- Anxiety transmission across generations
+- Relationship pattern repetition (triangles, cutoffs, fusion)
+- Functioning shifts that correlate across family members
+
+Be specific — name the people and events involved. Write in plain language a \
+non-clinician would understand. Return each pattern as a numbered item (1., 2., 3.).\
+"""
+
+
+async def generate_insights(pdp: PDP, conversation_history: str) -> list[str]:
+    """
+    Analyze extracted PDP for cross-generational patterns.
+
+    Takes the complete PDP (people, events, pair_bonds) and the conversation text.
+    Builds a prompt and calls the LLM to identify 2-3 patterns.
+
+    Returns a list of insight strings, or an empty list on error.
+    Never blocks extraction — errors are caught and logged.
+    """
+    try:
+        if not pdp.people and not pdp.events:
+            _log.info("No PDP data to analyze for insights")
+            return []
+
+        pdp_context = asdict(pdp)
+
+        prompt = (
+            f"{INSIGHTS_PROMPT}\n\n"
+            f"## Family Data (extracted)\n"
+            f"{pdp_context}\n\n"
+            f"## Conversation\n"
+            f"{conversation_history}\n"
+        )
+
+        response = gemini_text_sync(
+            prompt,
+            temperature=0.3,
+            max_output_tokens=1024,
+        )
+
+        if not response or not response.strip():
+            _log.warning("Empty response from LLM for insights")
+            return []
+
+        return _parse_insights(response.strip())
+
+    except Exception:
+        _log.exception("Failed to generate insights — returning empty list")
+        return []
+
+
+def _parse_insights(text: str) -> list[str]:
+    """
+    Parse LLM response into a list of insight strings.
+
+    Handles numbered lists (1. ..., 2. ...) and double-newline separated paragraphs.
+    """
+    # Try numbered list first: "1.", "2.", "3." etc.
+    numbered = re.split(r"\n\s*\d+\.\s+", text)
+    # The first element before "1." is usually empty or a preamble
+    if len(numbered) > 1:
+        insights = [s.strip() for s in numbered if s.strip()]
+        if insights:
+            return insights
+
+    # Fall back to double-newline separation
+    paragraphs = re.split(r"\n\s*\n", text)
+    insights = [p.strip() for p in paragraphs if p.strip()]
+    return insights if insights else [text.strip()]

--- a/btcopilot/personal/routes/discussions.py
+++ b/btcopilot/personal/routes/discussions.py
@@ -10,6 +10,7 @@ from btcopilot.extensions import db
 from btcopilot.pro.models import Diagram
 from btcopilot.schema import PDP, asdict
 from btcopilot.personal import Response, ask
+from btcopilot.personal.insights import generate_insights
 from btcopilot.personal.models import Discussion, Speaker, SpeakerType
 
 _log = logging.getLogger(__name__)
@@ -219,12 +220,17 @@ def extract(discussion_id: int):
     discussion.diagram.set_diagram_data(diagram_data)
     db.session.commit()
 
+    # Generate pattern insights (non-blocking — empty list on failure)
+    conversation_history = discussion.conversation_history()
+    insights = one_result(generate_insights(new_pdp, conversation_history))
+
     return jsonify(
         success=True,
         people_count=len(new_pdp.people),
         events_count=len(new_pdp.events),
         pair_bonds_count=len(new_pdp.pair_bonds),
         pdp=asdict(new_pdp),
+        insights=insights,
     )
 
 

--- a/btcopilot/tests/personal/test_insights.py
+++ b/btcopilot/tests/personal/test_insights.py
@@ -1,0 +1,240 @@
+"""Tests for the Pattern Intelligence (insights) feature."""
+
+import pytest
+from mock import patch, AsyncMock
+
+from btcopilot.extensions import db
+from btcopilot.personal.insights import generate_insights, _parse_insights
+from btcopilot.schema import (
+    PDP,
+    PDPDeltas,
+    Person,
+    Event,
+    EventKind,
+    PairBond,
+    asdict,
+)
+
+
+# --- Unit tests for _parse_insights ---
+
+
+def test_parse_numbered_list():
+    text = "1. Mom and Dad show a pattern of conflict.\n2. Anxiety rises across generations.\n3. Cutoff repeats in siblings."
+    result = _parse_insights(text)
+    assert len(result) == 3
+    assert "Mom and Dad" in result[0]
+    assert "Anxiety" in result[1]
+    assert "Cutoff" in result[2]
+
+
+def test_parse_double_newline():
+    text = "Mom and Dad show a pattern of conflict.\n\nAnxiety rises across generations.\n\nCutoff repeats in siblings."
+    result = _parse_insights(text)
+    assert len(result) == 3
+
+
+def test_parse_single_paragraph():
+    text = "This is a single insight about the family."
+    result = _parse_insights(text)
+    assert len(result) == 1
+    assert result[0] == text
+
+
+def test_parse_numbered_with_preamble():
+    text = "Here are the patterns:\n1. First pattern about Mom.\n2. Second pattern about Dad."
+    result = _parse_insights(text)
+    assert len(result) >= 2
+    assert "First pattern" in result[0] or "First pattern" in result[1]
+
+
+def test_parse_empty_string():
+    result = _parse_insights("")
+    assert result == [""]
+
+
+# --- Unit tests for generate_insights ---
+
+
+@pytest.mark.usefixtures("flask_app")
+class TestGenerateInsights:
+
+    def test_empty_pdp_returns_empty(self):
+        from btcopilot.async_utils import one_result
+
+        pdp = PDP()
+        result = one_result(generate_insights(pdp, "Some conversation"))
+        assert result == []
+
+    def test_returns_insights_on_success(self):
+        from btcopilot.async_utils import one_result
+
+        pdp = PDP(
+            people=[
+                Person(id=-1, name="Mom", gender="female"),
+                Person(id=-2, name="Dad", gender="male"),
+                Person(id=-3, name="Grandma", gender="female"),
+            ],
+            events=[
+                Event(
+                    id=-4,
+                    kind=EventKind.Shift,
+                    person=-1,
+                    description="Increased anxiety",
+                    dateTime="2024-01-01",
+                ),
+                Event(
+                    id=-5,
+                    kind=EventKind.Shift,
+                    person=-3,
+                    description="Chronic worry",
+                    dateTime="1995-06-01",
+                ),
+            ],
+            pair_bonds=[PairBond(id=-6, person_a=-1, person_b=-2)],
+        )
+        conversation = "Client: My mom worries a lot, just like my grandma did."
+
+        mock_response = (
+            "1. Anxiety transmission from Grandma to Mom: Both Grandma and Mom "
+            "show elevated anxiety patterns, suggesting intergenerational transmission.\n"
+            "2. Mom and Dad's relationship shows signs of emotional fusion, "
+            "which often correlates with increased anxiety in the system."
+        )
+
+        with patch(
+            "btcopilot.personal.insights.gemini_text_sync",
+            return_value=mock_response,
+        ):
+            result = one_result(generate_insights(pdp, conversation))
+
+        assert len(result) == 2
+        assert "Grandma" in result[0]
+        assert "Mom" in result[0]
+
+    def test_returns_empty_on_llm_error(self):
+        from btcopilot.async_utils import one_result
+
+        pdp = PDP(
+            people=[Person(id=-1, name="Mom")],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Shift,
+                    person=-1,
+                    description="Anxiety",
+                    dateTime="2024-01-01",
+                )
+            ],
+        )
+
+        with patch(
+            "btcopilot.personal.insights.gemini_text_sync",
+            side_effect=Exception("LLM unavailable"),
+        ):
+            result = one_result(generate_insights(pdp, "conversation"))
+
+        assert result == []
+
+    def test_returns_empty_on_empty_response(self):
+        from btcopilot.async_utils import one_result
+
+        pdp = PDP(
+            people=[Person(id=-1, name="Mom")],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Shift,
+                    person=-1,
+                    description="Anxiety",
+                    dateTime="2024-01-01",
+                )
+            ],
+        )
+
+        with patch(
+            "btcopilot.personal.insights.gemini_text_sync",
+            return_value="",
+        ):
+            result = one_result(generate_insights(pdp, "conversation"))
+
+        assert result == []
+
+
+# --- Integration test for extract endpoint with insights ---
+
+
+def test_extract_endpoint_returns_insights(subscriber, discussion):
+    """Extract endpoint should include insights field in response."""
+    mock_pdp = PDP(
+        people=[Person(id=-1, name="Mom", gender="female", confidence=0.8)],
+        events=[
+            Event(
+                id=-2,
+                kind=EventKind.Birth,
+                person=-1,
+                child=-1,
+                description="Born",
+                dateTime="1953-01-01",
+                confidence=0.8,
+            )
+        ],
+    )
+    mock_deltas = PDPDeltas(people=mock_pdp.people, events=mock_pdp.events)
+    mock_insights = [
+        "Mom's birth event marks the beginning of a pattern.",
+        "Cross-generational anxiety is evident.",
+    ]
+
+    with patch(
+        "btcopilot.pdp.extract_full",
+        AsyncMock(return_value=(mock_pdp, mock_deltas)),
+    ), patch(
+        "btcopilot.personal.routes.discussions.generate_insights",
+        AsyncMock(return_value=mock_insights),
+    ):
+        response = subscriber.post(
+            f"/personal/discussions/{discussion.id}/extract",
+        )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert "insights" in data
+    assert len(data["insights"]) == 2
+    assert "Mom" in data["insights"][0]
+
+
+def test_extract_endpoint_insights_failure_doesnt_block(subscriber, discussion):
+    """If insight generation fails, extraction should still succeed."""
+    mock_pdp = PDP(
+        people=[Person(id=-1, name="Mom", confidence=0.8)],
+        events=[
+            Event(
+                id=-2,
+                kind=EventKind.Shift,
+                person=-1,
+                description="Anxiety",
+                dateTime="2024-01-01",
+                confidence=0.8,
+            )
+        ],
+    )
+    mock_deltas = PDPDeltas(people=mock_pdp.people, events=mock_pdp.events)
+
+    with patch(
+        "btcopilot.pdp.extract_full",
+        AsyncMock(return_value=(mock_pdp, mock_deltas)),
+    ), patch(
+        "btcopilot.personal.routes.discussions.generate_insights",
+        AsyncMock(return_value=[]),  # Failure returns empty list
+    ):
+        response = subscriber.post(
+            f"/personal/discussions/{discussion.id}/extract",
+        )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert data["insights"] == []
+    assert data["people_count"] == 1


### PR DESCRIPTION
## Summary
- **New module** `btcopilot/personal/insights.py`: `generate_insights()` takes extracted PDP + conversation history and calls Gemini with temperature 0.3 to identify 2-3 cross-generational family patterns (anxiety transmission, relationship repetition, functioning shifts)
- **Extract endpoint** now returns `insights` field alongside PDP data — insight generation never blocks extraction (returns empty list on failure)
- **Frontend** (companion PR in familydiagram): `PersonalAppController` gains `insights` property + `runExtract()` slot; `LearnView.qml` displays insights as cards in the story list footer

## Test plan
- [x] `uv run pytest btcopilot/tests/personal/ -k insights` — 11 tests passing
- [x] Existing `test_extract_endpoint.py` tests still pass
- [ ] Manual: trigger extraction on a discussion with family data, verify insights appear in response
- [ ] Manual: verify insights display correctly in LearnView on iOS/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)