### PR TITLE
Upgrade extraction model to gemini-3.1-flash-lite-preview

### DIFF
--- a/btcopilot/llmutil.py
+++ b/btcopilot/llmutil.py
@@ -11,8 +11,8 @@ from btcopilot.schema import from_dict
 
 _log = logging.getLogger(__name__)
 
-EXTRACTION_MODEL = "gemini-2.5-flash"
-EXTRACTION_MODEL_LARGE = "gemini-2.5-flash"
+EXTRACTION_MODEL = "gemini-3.1-flash-lite-preview"
+EXTRACTION_MODEL_LARGE = "gemini-3.1-flash-lite-preview"
 RESPONSE_MODEL = "gemini-3-flash-preview"
 
 


### PR DESCRIPTION
## Summary

- Upgrade `EXTRACTION_MODEL` and `EXTRACTION_MODEL_LARGE` from `gemini-2.5-flash` to `gemini-3.1-flash-lite-preview`
- `RESPONSE_MODEL` stays on `gemini-3-flash-preview` (higher reasoning quality for chat)
- Drop-in replacement: same structured output / JSON schema support, same 1M context window, same 65K output limit

## Cost & Performance

| Metric | gemini-2.5-flash | gemini-3.1-flash-lite-preview | Delta |
|--------|-----------------|-------------------------------|-------|
| Input price | $0.30/1M | $0.25/1M | **17% cheaper** |
| Output price | $2.50/1M | $1.50/1M | **40% cheaper** |
| Output speed | ~249 tok/s | ~363 tok/s | **46% faster** |
| TTFT | ~0.52s | ~0.21s | **60% faster** |
| Context window | 1M | 1M | Same |
| Output limit | 65K | 65K | Same |

## Risk

- `gemini-3.1-flash-lite-preview` is in **preview** status (released 2026-03-03). No GA date announced yet.
- Preview models may change behavior without notice and may have tighter rate limits.

## Test plan

- [x] All 554 unit tests pass (LLM calls are mocked in tests)
- [ ] Run F1 prompt induction workflow (`GOOGLE_GEMINI_API_KEY=... uv run python -m btcopilot.training.test_prompts_live`) to validate extraction quality is maintained
- [ ] Monitor production extraction latency and error rates after deploy
- [ ] Fallback plan: revert to `gemini-2.5-flash` if F1 regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)