### PR TITLE
Evaluate gemini-flash-lite extraction baseline

### DIFF
--- a/MVP_DASHBOARD.md
+++ b/MVP_DASHBOARD.md
@@ -31,7 +31,7 @@ Full conversation → single LLM call → complete PDP → accept all → view d
 
 ### Done
 
-T0-1, T0-2, T0-3, T0-5 (crash blockers), T1-1 through T1-5 (extraction quality), T4-1 through T4-5 (synthetic pipeline), T5-4 through T5-6 (F1 infrastructure), T6-2 (cumulative F1 baseline established 2026-02-24), T7-1 (`extract_full()` implemented), T7-2 (extract endpoint), T7-3 (chat-only, extraction removed), T7-4 (extract button + PDP Refresh button in Personal app).
+T0-1, T0-2, T0-3, T0-5 (crash blockers), T1-1 through T1-5 (extraction quality), T4-1 through T4-5 (synthetic pipeline), T5-4 through T5-6 (F1 infrastructure), T6-2 (cumulative F1 baseline established 2026-02-24), T7-1 (`extract_full()` implemented), T7-2 (extract endpoint), T7-3 (chat-only, extraction removed), T7-4 (extract button + PDP Refresh button in Personal app), ~~T7-20~~ (gemini-flash-lite baseline eval — not viable, see [analysis](doc/analyses/gemini-flash-lite-baseline-20260303.md). DONE 2026-03-03).
 
 ---
 
@@ -99,10 +99,11 @@ T2-2, T2-3 (arrange error handling), T2-4, T2-6.
 
 ## Reference
 
-### Analyses (2026-02-20)
+### Analyses
 
 | Analysis | Covers |
 |----------|--------|
+| [Gemini Flash Lite Baseline](doc/analyses/gemini-flash-lite-baseline-20260303.md) | gemini-2.5-flash-lite eval: People=0.622, Events=0.103, Aggregate=0.216. Not viable. (2026-03-03) |
 | [PDP Extraction & Delta Acceptance](doc/analyses/2026-02-20_pdp_extraction_and_delta_acceptance.md) | Extraction pipeline, validation, commit flow, F1 |
 | [Synthetic Pipeline](doc/analyses/2026-02-20_synthetic_pipeline.md) | Celery tasks, error handling, evaluators |
 | [Personal App Beta Readiness](doc/analyses/2026-02-20_personal_app_beta_readiness.md) | Chat UX, PDP drawer, timeline, PlanView |
@@ -136,6 +137,7 @@ T2-2, T2-3 (arrange error handling), T2-4, T2-6.
 | 2026-02-24 | All open tasks | T0-4 deferred. T4-2 not needed. E2E pipeline verified. |
 | 2026-02-24 | Architecture pivot | Single-prompt extraction proven. Dashboard rewritten. See decision log 2026-02-24. |
 | 2026-02-26 | T7-1 through T7-4 | Implemented and moved to Done. Extract button + PDP Refresh in Personal app. Chat is chat-only. PDP cleared before re-extraction. All architecture docs updated. |
+| 2026-03-03 | T7-20 | gemini-2.5-flash-lite eval completed. People=0.622 (-0.098), Events=0.103 (-0.187), Aggregate=0.216 (-0.234). Not viable — stick with gemini-2.5-flash. |
 
 ### Deferred (Post-MVP)
 

--- a/doc/analyses/gemini-flash-lite-baseline-20260303.md
+++ b/doc/analyses/gemini-flash-lite-baseline-20260303.md
@@ -1,0 +1,74 @@
+# Gemini Flash Lite Extraction Baseline — 2026-03-03
+
+## Summary
+
+Evaluated `gemini-2.5-flash-lite` as a cheaper/faster alternative to `gemini-2.5-flash` for PDP extraction. Result: **significant quality degradation across all metrics**. Not viable as a drop-in replacement without prompt re-tuning.
+
+**Note:** The originally requested model `gemini-2.0-flash-lite` returned `404 NOT_FOUND` ("no longer available to new users"). `gemini-2.5-flash-lite` was used instead as the closest available lite variant.
+
+## Model Details
+
+| Property | Value |
+|----------|-------|
+| Model tested | `gemini-2.5-flash-lite` |
+| Baseline model | `gemini-2.5-flash` |
+| Eval script | `uv run python -m btcopilot.training.run_prompts_live --model gemini-2.5-flash-lite --detailed` |
+| Eval method | Per-statement live re-extraction via `pdp.update()` |
+| GT cases | 95 total, 85 evaluated, 10 errors |
+| Total runtime | 625 seconds (~10.4 min) |
+| Date | 2026-03-03 |
+
+## F1 Scores
+
+| Metric | gemini-2.5-flash-lite | Baseline (gemini-2.5-flash, Feb 2026) | Delta |
+|--------|-----------------------|---------------------------------------|-------|
+| **People F1** | 0.622 | 0.72 | **-0.098** |
+| **Events F1** | 0.103 | 0.29 | **-0.187** |
+| **PairBond F1** | N/A (per-statement eval) | 0.33 | — |
+| **Aggregate F1** | 0.216 | 0.45 | **-0.234** |
+| Symptom F1 | 0.212 | — | — |
+| Anxiety F1 | 0.235 | — | — |
+| Relationship F1 | 0.235 | — | — |
+| Functioning F1 | 0.212 | — | — |
+
+### Methodology Note
+
+The baseline metrics (People=0.72, Events=0.29, PairBond=0.33) were measured using cumulative F1 (`calculate_cumulative_f1()`) on discussion 48. This eval used per-statement F1 (`calculate_statement_f1()`) averaged across all 95 GT cases from 5 discussions. The metrics are not perfectly apples-to-apples but directionally comparable — the lite model is clearly worse on both People and Events extraction.
+
+## Error Breakdown
+
+| Error Type | Count | Details |
+|------------|-------|---------|
+| PDP validation failures | 7 | Person/Event references to non-existent PDP items (pair_bonds, relationship targets). Retried 4x before failing. |
+| Deadline exceeded (504) | 2 | Timeouts on larger conversation contexts (~15K+ chars). |
+| Output truncated | 1 | `MAX_TOKENS` hit — LLM response too large for token limit. |
+| **Total errors** | **10** | **10.5% error rate** (vs near-0% for gemini-2.5-flash) |
+
+### Key Observations
+
+1. **ID collision warnings were frequent.** The lite model frequently produced negative IDs that collided with existing PDP items, requiring `reassign_delta_ids` fixups. This suggests weaker instruction-following for the negative-ID convention.
+
+2. **Validation failures dominated errors.** 7/10 errors were the model referencing non-existent PDP items (pair_bonds, relationship targets) — the lite model doesn't reliably maintain referential integrity across the extraction schema.
+
+3. **Events F1 collapsed to 0.103.** Most statements got Events F1 = 0.000, meaning the lite model either fails to extract events or extracts wrong ones. The few successful event extractions were on simpler, shorter conversations.
+
+4. **People F1 held up relatively better (0.622 vs 0.72).** The lite model can still identify people mentioned in conversation but struggles with the more complex structured extraction (events, SARF variables, relationships).
+
+5. **Two timeouts on longer conversations.** The lite model may have higher latency on complex prompts or smaller context windows in practice.
+
+## Conclusion
+
+`gemini-2.5-flash-lite` is **not suitable** for PDP extraction at current prompt complexity. The 52% drop in aggregate F1 (0.216 vs 0.45) and 65% drop in Events F1 (0.103 vs 0.29) make it unusable for MVP. Stick with `gemini-2.5-flash` for extraction.
+
+If cost reduction is needed, consider:
+- Prompt simplification specifically for the lite model
+- Using lite only for People extraction (acceptable F1) and full model for Events
+- Waiting for future lite model improvements
+
+## Raw Output
+
+Full per-statement breakdown available by re-running:
+```bash
+export $(grep -v '^#' ~/.openclaw/.env | xargs)
+uv run python -m btcopilot.training.run_prompts_live --model gemini-2.5-flash-lite --detailed
+```


### PR DESCRIPTION
## Summary
- Ran extraction F1 evaluation with `gemini-2.5-flash-lite` as a cheaper alternative to `gemini-2.5-flash`
- Result: **not viable** — significant quality degradation across all metrics (People F1 0.622 vs 0.72, Events F1 0.103 vs 0.29, Aggregate 0.216 vs 0.45)
- Note: `gemini-2.0-flash-lite` (originally requested) returned 404 — deprecated for this account. Used `gemini-2.5-flash-lite` instead.

## Details
- 85/95 GT cases evaluated successfully, 10 errors (validation failures, timeouts, truncation)
- Analysis doc: `doc/analyses/gemini-flash-lite-baseline-20260303.md`
- MVP Dashboard updated with T7-20 completion and verification log entry

## Test plan
- [x] Ran `uv run python -m btcopilot.training.run_prompts_live --model gemini-2.5-flash-lite --detailed`
- [x] Recorded F1 scores and compared to baseline
- [x] Wrote analysis doc with full methodology and error breakdown
- [x] Updated MVP_DASHBOARD.md (Done list, Analyses table, Verification Log)

Closes patrickkidd/theapp#43

🤖 Generated with [Claude Code](https://claude.com/claude-code)