### PR TITLE
Fix Events F1: reduce over-extraction + committed-ID resolution

### DIFF
--- a/MVP_DASHBOARD.md
+++ b/MVP_DASHBOARD.md
@@ -22,10 +22,12 @@ Full conversation → single LLM call → complete PDP → accept all → view d
 |---|------|------|--------|-------|
 | T7-5 | Code GT for fresh discussions | H | ~3 hr | Patrick codes People/Events/PairBonds in SARF editor. ~60 min each. Synthetic discussions already generated in prod. |
 | T7-7 | Validate single-prompt F1 on fresh GT | CC | ~30 min | Run `calculate_cumulative_f1()` on T7-5 discussions. Target: People > 0.7, Events > 0.3. |
-| T7-8 | Prompt-tune on single-prompt path | CC+H | ~2 hr | Iterate on `fdserver/prompts/private_prompts.py` using fresh GT from T7-5. Stable surface — one call, low variance. |
+| T7-8 | Prompt-tune on single-prompt path | CC+H | ~2 hr | **In progress (Mar 2026)**: Over-extraction fixed — event counts now match GT (15 vs 14, 25 vs 24). But Events F1 still ~0.20 because AI extracts different events than GT coders (clinical judgment gap). Next steps: (1) review GT coding conventions with prompt examples, (2) add GT-aligned examples to `DATA_FULL_EXTRACTION_CONTEXT`, (3) investigate description matching thresholds. Fixed committed-ID resolution bug in f1_metrics.py. |
 | T7-9 | Validate idempotent re-extraction (no duplication after accept) | CC | ~1 hr | Chat → extract → accept all → extract again → verify no duplicate people/events vs committed items. Tests LLM-based dedup in `DATA_FULL_EXTRACTION_CONTEXT`. |
 | T7-10 | Fix birth event self-reference bug | CC+H | ~2 hr | Birth events set person=child (person births themselves). Should set person=parent, child=born person, create parent PairBonds, infer sibling relationships from existing data. Prompt rules, examples, and validation all need updating. Needs design discussion first. |
 | T7-11 | Fix extraction dedup against committed items | CC+H | ~2 hr | `extract_full` re-extracts people/events already committed in `diagram_data`. LLM prompt says "avoid duplicates with committed items" but isn't working. May need rules-based post-filter in `_extract_and_validate` or `apply_deltas` to strip entries matching committed IDs/names, not just prompt reliance. |
+| T7-12 | Auto-detect event clusters on PDP accept | CC+H | ~2-3 hr | Remove "Re-detect clusters" button, auto-detect on PDP accept, restore "Show clusters" checkbox. [Issue #31](https://github.com/patrickkidd/btcopilot/issues/31). Depends on T7-6. |
+| T7-13 | Fix timeline initial zoom and right-edge overflow | CC+H | ~1-2 hr | Timeline loads too zoomed in; last cluster runs off right edge. Fit all clusters in viewport on load, add right padding. [Issue #87](https://github.com/patrickkidd/familydiagram/issues/87). Can parallel T7-12. |
 | T5-1 | Fix 18 GT events with person=None | H | ~3 hr | SARF editor. Existing disc 48 GT cleanup. |
 | T5-2 | Fix 24 GT events with placeholder descriptions | H | ~4 hr | Read transcripts, write correct descriptions. |
 
@@ -79,7 +81,7 @@ T2-2, T2-3 (arrange error handling), T2-4, T2-6.
 | Risk | Impact | Mitigation |
 |------|--------|------------|
 | Single-prompt hits context limit on long conversations | Extraction fails or truncates | gemini-2.5-flash has 1M token context; typical discussion is ~30K chars. Monitor. |
-| Events F1 plateaus below 0.4 | Users see wrong events | Prompt-tune on stable single-prompt surface (T7-8). Fallback: hide events, show People/PairBonds only. |
+| Events F1 plateaus below 0.4 | Users see wrong events | Prompt-tune on stable single-prompt surface (T7-8). Over-extraction fixed; remaining gap is clinical judgment alignment (AI picks different events than GT). Fallback: hide events, show People/PairBonds only. Next: GT-aligned examples in prompt. |
 | GT coding bottleneck (Patrick only) | Limits measurement iterations | ~60 min/discussion is fast enough for 3-5 GT cases needed for MVP. |
 | Auto-arrange is 2-3 weeks | Delays Goal 3 | Consider simpler generational Y-alignment only. |
 
@@ -90,7 +92,7 @@ T2-2, T2-3 (arrange error handling), T2-4, T2-6.
 | Metric | Last Measured | Target | Notes |
 |--------|-------------|--------|-------|
 | People F1 (cumulative) | 0.72 (Feb 2026, single-prompt, disc 48) | > 0.7 | At target. Validate on fresh GT. |
-| Event F1 (cumulative) | 0.29 (Feb 2026, single-prompt, disc 48) | > 0.4 | Below target. Prompt tuning on T7-8. |
+| Event F1 (cumulative) | 0.20 avg (Mar 2026, single-prompt, disc 36/37/39/48) | > 0.4 | Below target. Over-extraction fixed (event counts now match GT). Remaining gap: AI extracts different events than GT coders (clinical judgment alignment). See T7-8 notes. |
 | PairBond F1 (cumulative) | 0.33 (Feb 2026, single-prompt, disc 48) | > 0.5 | Below target. |
 | GT coded discussions | 4 (disc 36/37/39/48) | 5-8 for MVP | T7-5 adds fresh GT coding. |
 | E2E synthetic | Verified 2026-02-24 | Functional | test_e2e_synthetic.py |
@@ -136,6 +138,7 @@ T2-2, T2-3 (arrange error handling), T2-4, T2-6.
 | 2026-02-24 | All open tasks | T0-4 deferred. T4-2 not needed. E2E pipeline verified. |
 | 2026-02-24 | Architecture pivot | Single-prompt extraction proven. Dashboard rewritten. See decision log 2026-02-24. |
 | 2026-02-26 | T7-1 through T7-4 | Implemented and moved to Done. Extract button + PDP Refresh in Personal app. Chat is chat-only. PDP cleared before re-extraction. All architecture docs updated. |
+| 2026-03-03 | T7-8 Events F1 | Over-extraction fixed (AI event counts now match GT: 15/14, 25/24, 19/18, 27/21 across disc 36/37/39/48). Events F1 avg ~0.20, not yet at 0.40 target. Root cause: AI-GT clinical judgment gap — different events selected despite similar counts. Fixed committed-ID resolution bug in f1_metrics.py. |
 
 ### Deferred (Post-MVP)
 

--- a/btcopilot/training/f1_metrics.py
+++ b/btcopilot/training/f1_metrics.py
@@ -942,6 +942,80 @@ def calculate_statement_f1(
     return metrics
 
 
+def _augment_committed_id_map(
+    id_map: dict[int, int],
+    ai_pdp: PDP,
+    gt_pdp: PDP,
+    discussion,
+) -> None:
+    """
+    Augment id_map with mappings for committed (positive) person IDs.
+
+    When diagram_data has duplicate entries for the same person (e.g., id=1
+    "Sarah" and id=3 "Sarah"), the AI extraction may reference a different
+    committed ID than the GT cumulative PDP uses. This causes false negatives
+    in event matching even when the AI correctly identified the right person.
+
+    This function finds committed IDs referenced in AI events that don't appear
+    in GT, and maps them to GT committed IDs by name matching against
+    diagram_data.
+    """
+    if not discussion.diagram:
+        return
+
+    diagram_data = discussion.diagram.get_diagram_data()
+    committed_people = diagram_data.people
+    if not committed_people:
+        return
+
+    # Collect all positive (committed) IDs referenced in AI events
+    ai_committed_ids = set()
+    for event in ai_pdp.events:
+        for field in ("person", "spouse", "child"):
+            pid = getattr(event, field, None)
+            if pid is not None and pid > 0:
+                ai_committed_ids.add(pid)
+        for pid in getattr(event, "relationshipTargets", []) or []:
+            if pid > 0:
+                ai_committed_ids.add(pid)
+
+    # Collect all positive IDs in GT people
+    gt_committed_ids = {p.id for p in gt_pdp.people if p.id > 0}
+
+    # Find AI committed IDs that aren't in GT and try to map them
+    for ai_id in ai_committed_ids:
+        if ai_id in id_map or ai_id in gt_committed_ids:
+            continue  # Already mapped or same ID exists in GT
+
+        # Find the name of this committed person in diagram_data
+        ai_name = None
+        for cp in committed_people:
+            cp_id = cp.get("id") if isinstance(cp, dict) else getattr(cp, "id", None)
+            if cp_id == ai_id:
+                ai_name = (
+                    cp.get("name") if isinstance(cp, dict) else getattr(cp, "name", None)
+                )
+                break
+
+        if not ai_name:
+            continue
+
+        # Try to match this name to a GT committed person
+        ai_normalized = normalize_name_for_matching(ai_name)
+        for gt_person in gt_pdp.people:
+            if gt_person.id <= 0 or gt_person.id in id_map.values():
+                continue
+            gt_normalized = normalize_name_for_matching(gt_person.name)
+            sim = fuzz.token_set_ratio(ai_normalized, gt_normalized) / 100.0
+            if sim >= NAME_SIMILARITY_THRESHOLD:
+                id_map[ai_id] = gt_person.id
+                _log.debug(
+                    f"Committed ID map: AI {ai_id} ({ai_name}) -> "
+                    f"GT {gt_person.id} ({gt_person.name})"
+                )
+                break
+
+
 def calculate_cumulative_f1(discussion_id: int) -> CumulativeF1Metrics:
     from btcopilot.personal.models import Discussion, Statement
     from btcopilot.training.models import Feedback
@@ -981,6 +1055,14 @@ def calculate_cumulative_f1(discussion_id: int) -> CumulativeF1Metrics:
     )
 
     people_result, id_map = match_people(ai_pdp.people, gt_pdp.people)
+
+    # Resolve committed person ID mismatches: when diagram_data has duplicate
+    # entries for the same person (e.g., id=1 "Sarah" and id=3 "Sarah"), the AI
+    # may reference a different committed ID than GT uses. Add mappings for any
+    # committed (positive) IDs referenced in AI events that match GT people.
+    if discussion.diagram:
+        _augment_committed_id_map(id_map, ai_pdp, gt_pdp, discussion)
+
     events_result = match_events(ai_pdp.events, gt_pdp.events, id_map)
     bonds_result = match_pair_bonds(ai_pdp.pair_bonds, gt_pdp.pair_bonds, id_map)
 


### PR DESCRIPTION
## Summary
- **F1 measurement fix**: Added `_augment_committed_id_map()` to resolve committed person ID mismatches in cumulative F1 calculation. When `diagram_data` has duplicate entries for the same person, AI extraction references a different committed ID than GT, causing systematic false negatives.
- **MVP Dashboard update**: Documented March 2026 Events F1 findings — over-extraction fixed (event counts now match GT), but F1 still ~0.20 due to AI-GT clinical judgment alignment gap.
- **Companion PR**: fdserver prompt changes in patrickkidd/fdserver feat/tl-49

## Test plan
- [ ] Run `calculate_cumulative_f1()` for discussions 36, 37, 39, 48 and verify no regressions
- [ ] Verify `_augment_committed_id_map()` correctly maps duplicate committed IDs
- [ ] Review MVP_DASHBOARD.md updates for accuracy

Closes patrickkidd/theapp#49

🤖 Generated with [Claude Code](https://claude.com/claude-code)