### PR TITLE
Add per-entity-type F1 breakdown to eval harness

### DIFF
--- a/btcopilot/tests/training/test_run_extract_full_f1.py
+++ b/btcopilot/tests/training/test_run_extract_full_f1.py
@@ -1,0 +1,223 @@
+"""Tests for the entity-type breakdown in run_extract_full_f1."""
+
+import json
+import os
+import tempfile
+
+from btcopilot.training.run_extract_full_f1 import (
+    _build_entity_type_breakdown,
+    _print_entity_type_table,
+    _save_breakdown_json,
+)
+
+
+def _make_results():
+    """Build sample per-discussion results for testing."""
+    return [
+        {
+            "discussion_id": 1,
+            "summary": "Discussion A",
+            "people_f1": 0.8,
+            "events_f1": 0.4,
+            "pair_bonds_f1": 1.0,
+            "aggregate_f1": 0.7,
+            "people_tp": 3,
+            "people_fp": 1,
+            "people_fn": 0,
+            "events_tp": 2,
+            "events_fp": 1,
+            "events_fn": 2,
+            "bonds_tp": 1,
+            "bonds_fp": 0,
+            "bonds_fn": 0,
+            "sarf": {},
+            "elapsed": 5.0,
+        },
+        {
+            "discussion_id": 2,
+            "summary": "Discussion B",
+            "people_f1": 1.0,
+            "events_f1": 0.5,
+            "pair_bonds_f1": 0.0,
+            "aggregate_f1": 0.6,
+            "people_tp": 2,
+            "people_fp": 0,
+            "people_fn": 0,
+            "events_tp": 3,
+            "events_fp": 2,
+            "events_fn": 1,
+            "bonds_tp": 0,
+            "bonds_fp": 0,
+            "bonds_fn": 2,
+            "sarf": {},
+            "elapsed": 3.0,
+        },
+    ]
+
+
+def test_build_entity_type_breakdown_structure():
+    """Breakdown contains People, Events, PairBond with correct keys."""
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+
+    assert set(breakdown.keys()) == {"People", "Events", "PairBond"}
+    for label in ["People", "Events", "PairBond"]:
+        row = breakdown[label]
+        assert set(row.keys()) == {"tp", "fp", "fn", "precision", "recall", "f1"}
+
+
+def test_build_entity_type_breakdown_aggregates_counts():
+    """TP/FP/FN are summed across discussions."""
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+
+    # People: 3+2=5 TP, 1+0=1 FP, 0+0=0 FN
+    assert breakdown["People"]["tp"] == 5
+    assert breakdown["People"]["fp"] == 1
+    assert breakdown["People"]["fn"] == 0
+
+    # Events: 2+3=5 TP, 1+2=3 FP, 2+1=3 FN
+    assert breakdown["Events"]["tp"] == 5
+    assert breakdown["Events"]["fp"] == 3
+    assert breakdown["Events"]["fn"] == 3
+
+    # PairBond: 1+0=1 TP, 0+0=0 FP, 0+2=2 FN
+    assert breakdown["PairBond"]["tp"] == 1
+    assert breakdown["PairBond"]["fp"] == 0
+    assert breakdown["PairBond"]["fn"] == 2
+
+
+def test_build_entity_type_breakdown_computes_f1():
+    """Precision, recall, F1 are computed from aggregated counts."""
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+
+    # People: P=5/(5+1)=0.8333, R=5/(5+0)=1.0, F1=2*0.8333*1.0/(0.8333+1.0)
+    assert breakdown["People"]["precision"] > 0.83
+    assert breakdown["People"]["recall"] == 1.0
+    assert breakdown["People"]["f1"] > 0.9
+
+    # Events: P=5/(5+3)=0.625, R=5/(5+3)=0.625, F1=0.625
+    assert abs(breakdown["Events"]["precision"] - 0.625) < 0.001
+    assert abs(breakdown["Events"]["recall"] - 0.625) < 0.001
+    assert abs(breakdown["Events"]["f1"] - 0.625) < 0.001
+
+
+def test_build_entity_type_breakdown_all_zeros():
+    """All-zero counts produce zero F1 without errors."""
+    results = [
+        {
+            "people_tp": 0, "people_fp": 0, "people_fn": 0,
+            "events_tp": 0, "events_fp": 0, "events_fn": 0,
+            "bonds_tp": 0, "bonds_fp": 0, "bonds_fn": 0,
+        }
+    ]
+    breakdown = _build_entity_type_breakdown(results)
+
+    for label in ["People", "Events", "PairBond"]:
+        row = breakdown[label]
+        assert row["tp"] == 0
+        assert row["f1"] >= 0.0  # 0.0 or 1.0 depending on calculate_f1_from_counts
+
+
+def test_print_entity_type_table(capsys):
+    """Table prints with correct headers and all three entity types."""
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+    _print_entity_type_table(breakdown)
+
+    captured = capsys.readouterr().out
+    assert "ENTITY-TYPE BREAKDOWN" in captured
+    assert "People" in captured
+    assert "Events" in captured
+    assert "PairBond" in captured
+    assert "TP" in captured
+    assert "FP" in captured
+    assert "FN" in captured
+    assert "Prec" in captured
+    assert "Recall" in captured
+    assert "F1" in captured
+
+
+def test_save_breakdown_json_creates_file():
+    """JSON artifact is saved to the specified directory."""
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+    summary = {
+        "count": 2,
+        "people_f1": 0.9,
+        "events_f1": 0.45,
+        "pair_bonds_f1": 0.5,
+        "aggregate_f1": 0.65,
+        "per_discussion": results,
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = _save_breakdown_json(summary, breakdown, tmpdir)
+
+        assert os.path.exists(filepath)
+        assert filepath.startswith(tmpdir)
+        assert filepath.endswith(".json")
+
+        with open(filepath) as f:
+            artifact = json.load(f)
+
+        assert "timestamp" in artifact
+        assert "aggregate" in artifact
+        assert "entity_type_breakdown" in artifact
+        assert "per_discussion" in artifact
+
+        assert artifact["aggregate"]["count"] == 2
+        assert artifact["aggregate"]["aggregate_f1"] == 0.65
+
+        assert set(artifact["entity_type_breakdown"].keys()) == {
+            "People",
+            "Events",
+            "PairBond",
+        }
+        assert artifact["entity_type_breakdown"]["People"]["tp"] == 5
+
+
+def test_save_breakdown_json_creates_output_dir():
+    """Output directory is created if it doesn't exist."""
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+    summary = {
+        "count": 1,
+        "people_f1": 0.8,
+        "events_f1": 0.4,
+        "pair_bonds_f1": 1.0,
+        "aggregate_f1": 0.7,
+        "per_discussion": results[:1],
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nested = os.path.join(tmpdir, "sub", "dir")
+        filepath = _save_breakdown_json(summary, breakdown, nested)
+
+        assert os.path.exists(filepath)
+        assert os.path.isdir(nested)
+
+
+def test_run_extract_full_f1_returns_breakdown_key():
+    """The returned summary dict includes entity_type_breakdown key.
+
+    This is a structural test — we build the summary the same way the
+    function does, without requiring Flask/DB context.
+    """
+    results = _make_results()
+    breakdown = _build_entity_type_breakdown(results)
+    summary = {
+        "count": len(results),
+        "people_f1": 0.9,
+        "events_f1": 0.45,
+        "pair_bonds_f1": 0.5,
+        "aggregate_f1": 0.65,
+        "entity_type_breakdown": breakdown,
+        "per_discussion": results,
+    }
+
+    assert "entity_type_breakdown" in summary
+    assert "People" in summary["entity_type_breakdown"]
+    assert "Events" in summary["entity_type_breakdown"]
+    assert "PairBond" in summary["entity_type_breakdown"]

--- a/btcopilot/training/run_extract_full_f1.py
+++ b/btcopilot/training/run_extract_full_f1.py
@@ -9,12 +9,16 @@ Usage:
     uv run python -m btcopilot.training.run_extract_full_f1
     uv run python -m btcopilot.training.run_extract_full_f1 --discussion 50
     uv run python -m btcopilot.training.run_extract_full_f1 --model gemini-2.5-flash
+    uv run python -m btcopilot.training.run_extract_full_f1 --output-dir /tmp/eval
 """
 
 import argparse
 import asyncio
+import json
+import os
 import sys
 import time
+from datetime import datetime
 
 import nest_asyncio
 
@@ -31,7 +35,78 @@ from btcopilot.training.f1_metrics import (
 from btcopilot import pdp
 
 
-def run_extract_full_f1(discussion_id=None, model=None):
+def _build_entity_type_breakdown(results):
+    """Build per-entity-type F1 breakdown from per-discussion results.
+
+    Returns a dict with People/Events/PairBond keys, each containing
+    aggregated TP/FP/FN/precision/recall/F1.
+    """
+    breakdown = {}
+    for label, tp_key, fp_key, fn_key in [
+        ("People", "people_tp", "people_fp", "people_fn"),
+        ("Events", "events_tp", "events_fp", "events_fn"),
+        ("PairBond", "bonds_tp", "bonds_fp", "bonds_fn"),
+    ]:
+        total_tp = sum(r[tp_key] for r in results)
+        total_fp = sum(r[fp_key] for r in results)
+        total_fn = sum(r[fn_key] for r in results)
+        metrics = calculate_f1_from_counts(total_tp, total_fp, total_fn)
+        breakdown[label] = {
+            "tp": total_tp,
+            "fp": total_fp,
+            "fn": total_fn,
+            "precision": round(metrics.precision, 4),
+            "recall": round(metrics.recall, 4),
+            "f1": round(metrics.f1, 4),
+        }
+    return breakdown
+
+
+def _print_entity_type_table(breakdown):
+    """Print a formatted table of per-entity-type F1 breakdown."""
+    header = f"{'Entity Type':<12} {'TP':>4} {'FP':>4} {'FN':>4} {'Prec':>7} {'Recall':>7} {'F1':>7}"
+    separator = "-" * len(header)
+    print()
+    print("ENTITY-TYPE BREAKDOWN")
+    print(separator)
+    print(header)
+    print(separator)
+    for label in ["People", "Events", "PairBond"]:
+        row = breakdown[label]
+        print(
+            f"{label:<12} {row['tp']:>4} {row['fp']:>4} {row['fn']:>4} "
+            f"{row['precision']:>7.3f} {row['recall']:>7.3f} {row['f1']:>7.3f}"
+        )
+    print(separator)
+
+
+def _save_breakdown_json(summary, breakdown, output_dir):
+    """Save entity-type breakdown as a JSON artifact.
+
+    Returns the path to the saved file.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"extract_full_f1_breakdown_{timestamp}.json"
+    filepath = os.path.join(output_dir, filename)
+    artifact = {
+        "timestamp": datetime.now().isoformat(),
+        "aggregate": {
+            "count": summary["count"],
+            "people_f1": summary["people_f1"],
+            "events_f1": summary["events_f1"],
+            "pair_bonds_f1": summary["pair_bonds_f1"],
+            "aggregate_f1": summary["aggregate_f1"],
+        },
+        "entity_type_breakdown": breakdown,
+        "per_discussion": summary["per_discussion"],
+    }
+    with open(filepath, "w") as f:
+        json.dump(artifact, f, indent=2, default=str)
+    return filepath
+
+
+def run_extract_full_f1(discussion_id=None, model=None, output_dir=None):
     nest_asyncio.apply()
 
     if model:
@@ -145,6 +220,9 @@ def run_extract_full_f1(discussion_id=None, model=None):
             "events_tp": events_f1_metrics.tp,
             "events_fp": events_f1_metrics.fp,
             "events_fn": events_f1_metrics.fn,
+            "bonds_tp": bonds_f1_metrics.tp,
+            "bonds_fp": bonds_f1_metrics.fp,
+            "bonds_fn": bonds_f1_metrics.fn,
             "sarf": sarf,
             "elapsed": elapsed,
         }
@@ -200,6 +278,10 @@ def run_extract_full_f1(discussion_id=None, model=None):
             )
     print("=" * 60)
 
+    # Entity-type breakdown (aggregated TP/FP/FN across all discussions)
+    breakdown = _build_entity_type_breakdown(results)
+    _print_entity_type_table(breakdown)
+
     # Target check
     people_pass = avg_people > 0.7
     events_pass = avg_events > 0.3
@@ -211,14 +293,22 @@ def run_extract_full_f1(discussion_id=None, model=None):
         for disc_id, err in errors:
             print(f"  Disc {disc_id}: {err[:100]}")
 
-    return {
+    summary = {
         "count": n,
         "people_f1": avg_people,
         "events_f1": avg_events,
         "pair_bonds_f1": avg_bonds,
         "aggregate_f1": avg_aggregate,
+        "entity_type_breakdown": breakdown,
         "per_discussion": results,
     }
+
+    # Save JSON artifact if output directory specified
+    if output_dir:
+        filepath = _save_breakdown_json(summary, breakdown, output_dir)
+        print(f"\nBreakdown JSON saved to: {filepath}")
+
+    return summary
 
 
 def main():
@@ -235,12 +325,19 @@ def main():
         type=str,
         help="Override extraction model",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        help="Directory to save breakdown JSON artifact",
+    )
     args = parser.parse_args()
 
     app = create_app()
     with app.app_context():
         result = run_extract_full_f1(
-            discussion_id=args.discussion, model=args.model
+            discussion_id=args.discussion,
+            model=args.model,
+            output_dir=args.output_dir,
         )
         sys.exit(0 if result and result["count"] > 0 else 1)
 


### PR DESCRIPTION
## Summary
- Adds a printed entity-type breakdown table (People/Events/PairBond) with aggregated TP/FP/FN/Precision/Recall/F1 after the existing aggregate summary in `run_extract_full_f1.py`
- Adds `--output-dir` flag to save the breakdown as a timestamped JSON artifact alongside eval output
- Adds `entity_type_breakdown` key to the returned summary dict
- Includes `bonds_tp/fp/fn` in per-discussion result dicts (was missing)
- Existing aggregate reporting behavior is unchanged

Closes patrickkidd/theapp#69

## Test plan
- [x] 8 new unit tests in `test_run_extract_full_f1.py` (all passing)
- [ ] Run `uv run python -m btcopilot.training.run_extract_full_f1` to verify printed table appears after aggregate
- [ ] Run with `--output-dir /tmp/eval` to verify JSON artifact is saved
- [ ] Verify existing aggregate output is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)