### PR TITLE
Add missing test coverage for personal app endpoints

### DIFF
--- a/btcopilot/tests/personal/test_clusters.py
+++ b/btcopilot/tests/personal/test_clusters.py
@@ -1,4 +1,5 @@
 import pickle
+from enum import Enum
 
 from unittest.mock import patch, MagicMock
 
@@ -13,7 +14,21 @@ from btcopilot.schema import (
     ClusterResult,
     asdict,
 )
-from btcopilot.personal.clusters import compute_cache_key, detect_clusters
+from btcopilot.personal.clusters import compute_cache_key, detect_clusters, _enum_value
+
+
+def test_enum_value_with_enum():
+    class Color(Enum):
+        RED = "red"
+    assert _enum_value(Color.RED) == "red"
+
+
+def test_enum_value_with_plain_string():
+    assert _enum_value("up") == "up"
+
+
+def test_enum_value_with_none():
+    assert _enum_value(None) is None
 
 
 def test_compute_cache_key_empty():
@@ -160,6 +175,22 @@ def test_detect_clusters_route_success(subscriber):
     assert "cacheKey" in data
     assert len(data["clusters"]) == 1
     assert data["clusters"][0]["title"] == "Anxiety Cascade"
+
+
+def test_detect_clusters_llm_returns_none():
+    """When LLM returns None, detect_clusters returns empty cluster list."""
+    events = [
+        Event(id=1, kind=EventKind.Shift, dateTime="2024-01-15", description="Test"),
+    ]
+
+    with patch(
+        "btcopilot.personal.clusters.gemini_structured_sync", return_value=None
+    ):
+        result = detect_clusters(events)
+
+    assert isinstance(result, ClusterResult)
+    assert result.clusters == []
+    assert result.cacheKey is not None
 
 
 def test_detect_clusters_idempotent():

--- a/btcopilot/tests/personal/test_diagrams.py
+++ b/btcopilot/tests/personal/test_diagrams.py
@@ -155,3 +155,82 @@ def test_diagrams_optimistic_locking_conflict(subscriber):
 
     diagram = Diagram.query.get(diagram.id)
     assert diagram.version == initial_version
+
+
+def test_get_diagram_not_found(subscriber):
+    response = subscriber.get("/personal/diagrams/99999")
+    assert response.status_code == 404
+
+
+def test_get_diagram_forbidden(subscriber, test_user_2):
+    test_user_2.set_free_diagram(pickle.dumps({}))
+    db.session.commit()
+    other_diagram = test_user_2.free_diagram
+
+    response = subscriber.get(f"/personal/diagrams/{other_diagram.id}")
+    assert response.status_code == 403
+
+
+def test_update_diagram_not_found(subscriber):
+    response = subscriber.put(
+        "/personal/diagrams/99999",
+        json={"data": base64.b64encode(pickle.dumps({})).decode("utf-8")},
+    )
+    assert response.status_code == 404
+
+
+def test_update_diagram_forbidden(subscriber, test_user_2):
+    test_user_2.set_free_diagram(pickle.dumps({}))
+    db.session.commit()
+    other_diagram = test_user_2.free_diagram
+
+    response = subscriber.put(
+        f"/personal/diagrams/{other_diagram.id}",
+        json={"data": base64.b64encode(pickle.dumps({})).decode("utf-8")},
+    )
+    assert response.status_code == 403
+
+
+def test_update_diagram_without_data_field(subscriber):
+    """PUT without 'data' or 'expected_version' triggers version conflict (409)."""
+    diagram = subscriber.user.free_diagram
+
+    response = subscriber.put(
+        f"/personal/diagrams/{diagram.id}",
+        json={},
+    )
+    # No expected_version → version check fails → 409
+    assert response.status_code == 409
+    data = response.get_json()
+    assert "version" in data
+    assert "data" in data
+
+
+def test_get_diagram_discussions(subscriber, discussion):
+    """Test GET /diagrams/<id>/discussions returns discussion list."""
+    diagram = subscriber.user.free_diagram
+
+    response = subscriber.get(f"/personal/diagrams/{diagram.id}/discussions")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    # Each discussion should include statements and speakers
+    assert "statements" in data[0]
+    assert "speakers" in data[0]
+
+
+def test_get_diagram_discussions_not_found(subscriber):
+    response = subscriber.get("/personal/diagrams/99999/discussions")
+    assert response.status_code == 404
+
+
+def test_get_diagram_discussions_forbidden(subscriber, test_user_2):
+    test_user_2.set_free_diagram(pickle.dumps({}))
+    db.session.commit()
+    other_diagram = test_user_2.free_diagram
+
+    response = subscriber.get(
+        f"/personal/diagrams/{other_diagram.id}/discussions"
+    )
+    assert response.status_code == 403

--- a/btcopilot/tests/personal/test_discussions.py
+++ b/btcopilot/tests/personal/test_discussions.py
@@ -71,6 +71,16 @@ def test_get_404(subscriber):
     assert response.status_code == 404
 
 
+def test_get_unauthorized(subscriber, test_user_2):
+    """Accessing another user's discussion returns 401."""
+    other_discussion = Discussion(user_id=test_user_2.id, summary="Other user's")
+    db.session.add(other_discussion)
+    db.session.commit()
+
+    response = subscriber.get(f"/personal/discussions/{other_discussion.id}")
+    assert response.status_code == 401
+
+
 # def test_get_statements(subscriber, discussion):
 #     """Test getting statements for a discussion"""
 #     discussion_id = discussion.id

--- a/btcopilot/tests/personal/test_extract_endpoint.py
+++ b/btcopilot/tests/personal/test_extract_endpoint.py
@@ -57,3 +57,21 @@ def test_extract_no_diagram(subscriber):
 
     response = subscriber.post(f"/personal/discussions/{discussion.id}/extract")
     assert response.status_code == 400
+
+
+def test_extract_unauthorized(subscriber, test_user_2):
+    """Extracting from another user's discussion returns 401."""
+    from btcopilot.personal.models import Discussion
+
+    other_discussion = Discussion(
+        user_id=test_user_2.id,
+        diagram_id=test_user_2.free_diagram_id if test_user_2.free_diagram else None,
+        summary="Other user's discussion",
+    )
+    db.session.add(other_discussion)
+    db.session.commit()
+
+    response = subscriber.post(
+        f"/personal/discussions/{other_discussion.id}/extract"
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Add 14 new test cases covering previously untested code paths in the personal module
- **Diagrams**: GET 404/403, PUT 404/403/missing-data, GET discussions endpoint (404/403/success)
- **Discussions**: GET unauthorized access (401)
- **Extract endpoint**: POST unauthorized access (401)
- **Clusters**: `_enum_value` helper (enum, string, None), `detect_clusters` when LLM returns None

## Test plan
- [x] All 81 personal tests pass (`uv run pytest btcopilot/tests/personal/ -v -m "not e2e"`)
- [x] No production code modified — test-only changes
- [x] Tests follow existing patterns (fixtures, mocking, auth checks)

Closes patrickkidd/theapp#70

🤖 Generated with [Claude Code](https://claude.com/claude-code)