### PR TITLE
Fix birth event self-reference bug (T7-10)

### DIFF
--- a/btcopilot/pdp.py
+++ b/btcopilot/pdp.py
@@ -164,6 +164,29 @@ def dedup_pair_bonds(deltas: PDPDeltas) -> None:
                 person.parents = remap[person.parents]
 
 
+def _fix_birth_self_references(deltas: PDPDeltas) -> None:
+    """Fix birth/adopted events where person == child (self-referential).
+
+    The correct semantic: child = who was born, person = optional parent.
+    When the LLM sets person = child, clear person to None since the parent
+    is unknown.
+    """
+    for event in deltas.events:
+        if event.kind in (EventKind.Birth, EventKind.Adopted):
+            if event.child is not None and event.person is not None and event.child == event.person:
+                _log.warning(
+                    f"_fix_birth_self_references: event {event.id} has person == child == {event.child}, "
+                    f"clearing person to None"
+                )
+                event.person = None
+            if event.child is not None and event.spouse is not None and event.child == event.spouse:
+                _log.warning(
+                    f"_fix_birth_self_references: event {event.id} has spouse == child == {event.child}, "
+                    f"clearing spouse to None"
+                )
+                event.spouse = None
+
+
 def validate_pdp_deltas(
     pdp: PDP,
     deltas: PDPDeltas,
@@ -244,6 +267,20 @@ def validate_pdp_deltas(
             errors.append(
                 f"Delta pair_bond has positive ID {pair_bond.id} not in committed diagram"
             )
+
+    # Check for self-referential birth/adopted events
+    for event in deltas.events:
+        if event.kind in (EventKind.Birth, EventKind.Adopted):
+            if event.child is not None and event.person is not None and event.child == event.person:
+                errors.append(
+                    f"Birth/Adopted event {event.id} has self-referential child == person "
+                    f"({event.child}): a person cannot be a participant in their own birth"
+                )
+            if event.child is not None and event.spouse is not None and event.child == event.spouse:
+                errors.append(
+                    f"Birth/Adopted event {event.id} has self-referential child == spouse "
+                    f"({event.child}): a person cannot be a participant in their own birth"
+                )
 
     for event in deltas.events:
         # Offspring and moved events may lack spouse at extraction time; commit logic infers it
@@ -563,6 +600,7 @@ async def _extract_and_validate(
 
         reassign_delta_ids(pdp, pdp_deltas)
         dedup_pair_bonds(pdp_deltas)
+        _fix_birth_self_references(pdp_deltas)
         try:
             validate_pdp_deltas(pdp, pdp_deltas, diagram_data, source)
             if attempt > 0:

--- a/btcopilot/personal/prompts.py
+++ b/btcopilot/personal/prompts.py
@@ -383,7 +383,7 @@ functioning changes.
 
 **EVENT.PERSON ASSIGNMENT**: Every Event MUST have the correct `person` field.
 - `"death"`: person = who DIED (not the speaker)
-- `"birth"`: person = who was BORN, child = same ID
+- `"birth"`: child = who was BORN, person = parent (optional, null if unknown)
 - `"married"/"bonded"/"separated"/"divorced"`: person = one partner, spouse = other
 - `"shift"` with relationship: person = who INITIATED the behavior
 - `"shift"` without relationship: person = who is experiencing the change
@@ -453,7 +453,7 @@ Output:
         {
             "id": -2,
             "kind": "birth",
-            "person": -1,
+            "person": null,
             "child": -1,
             "description": "Born",
             "dateTime": "1953-01-01",
@@ -464,6 +464,10 @@ Output:
     "pair_bonds": [],
     "delete": []
 }
+
+IMPORTANT: For birth events, `child` is who was born (Barbara). `person` is an
+optional parent link — set to null when the parent is unknown. NEVER set
+person = child (self-referential birth is semantically invalid).
 
 Example 2: Extracting a relationship shift
 

--- a/btcopilot/tests/personal/test_birth_self_reference.py
+++ b/btcopilot/tests/personal/test_birth_self_reference.py
@@ -1,0 +1,290 @@
+"""Regression tests for birth event self-reference bug (T7-10 / GitHub #70).
+
+Birth events must use child = who was born, person/spouse = optional parent links.
+A person must never appear as both child and person/spouse on the same birth event.
+"""
+
+import pytest
+
+from btcopilot.schema import (
+    PDP,
+    PDPDeltas,
+    Person,
+    Event,
+    EventKind,
+    PairBond,
+    DiagramData,
+    PDPValidationError,
+)
+from btcopilot.pdp import (
+    validate_pdp_deltas,
+    apply_deltas,
+    _fix_birth_self_references,
+)
+
+
+class TestBirthSelfReferenceValidation:
+    """validate_pdp_deltas must reject self-referential birth events."""
+
+    def test_birth_event_person_equals_child_rejected(self):
+        """Birth event where person == child is invalid (self-referential)."""
+        pdp = PDP(
+            people=[Person(id=-1, name="Barbara", gender="female")],
+        )
+        deltas = PDPDeltas(
+            people=[],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Birth,
+                    person=-1,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        with pytest.raises(PDPValidationError, match="self-referential"):
+            validate_pdp_deltas(pdp, deltas)
+
+    def test_birth_event_spouse_equals_child_rejected(self):
+        """Birth event where spouse == child is invalid."""
+        pdp = PDP(
+            people=[
+                Person(id=-1, name="Barbara", gender="female"),
+                Person(id=-2, name="John", gender="male"),
+            ],
+        )
+        deltas = PDPDeltas(
+            people=[],
+            events=[
+                Event(
+                    id=-3,
+                    kind=EventKind.Birth,
+                    person=-2,
+                    spouse=-1,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        with pytest.raises(PDPValidationError, match="self-referential"):
+            validate_pdp_deltas(pdp, deltas)
+
+    def test_adopted_event_person_equals_child_rejected(self):
+        """Adopted event where person == child is also invalid."""
+        pdp = PDP(
+            people=[Person(id=-1, name="Child", gender="female")],
+        )
+        deltas = PDPDeltas(
+            people=[],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Adopted,
+                    person=-1,
+                    child=-1,
+                    description="Adopted",
+                    dateTime="2000-01-01",
+                )
+            ],
+        )
+        with pytest.raises(PDPValidationError, match="self-referential"):
+            validate_pdp_deltas(pdp, deltas)
+
+    def test_birth_event_with_correct_semantics_accepted(self):
+        """Birth event with child != person is valid."""
+        pdp = PDP(
+            people=[
+                Person(id=-1, name="Barbara", gender="female"),
+                Person(id=-2, name="Mother", gender="female"),
+            ],
+        )
+        deltas = PDPDeltas(
+            people=[],
+            events=[
+                Event(
+                    id=-3,
+                    kind=EventKind.Birth,
+                    person=-2,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        # Should not raise
+        validate_pdp_deltas(pdp, deltas)
+
+    def test_birth_event_with_person_none_accepted(self):
+        """Birth event with person=None (parent unknown) is valid per spec."""
+        pdp = PDP(
+            people=[Person(id=-1, name="Barbara", gender="female")],
+        )
+        deltas = PDPDeltas(
+            people=[],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Birth,
+                    person=None,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        # Should not raise
+        validate_pdp_deltas(pdp, deltas)
+
+
+class TestFixBirthSelfReferences:
+    """_fix_birth_self_references sanitizes LLM output before validation."""
+
+    def test_fixes_person_equals_child(self):
+        """When person == child on birth, person is cleared to None."""
+        deltas = PDPDeltas(
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Birth,
+                    person=-1,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        _fix_birth_self_references(deltas)
+        assert deltas.events[0].person is None
+        assert deltas.events[0].child == -1
+
+    def test_fixes_spouse_equals_child(self):
+        """When spouse == child on birth, spouse is cleared to None."""
+        deltas = PDPDeltas(
+            events=[
+                Event(
+                    id=-3,
+                    kind=EventKind.Birth,
+                    person=-2,
+                    spouse=-1,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        _fix_birth_self_references(deltas)
+        assert deltas.events[0].spouse is None
+        assert deltas.events[0].person == -2
+        assert deltas.events[0].child == -1
+
+    def test_does_not_touch_correct_birth_events(self):
+        """Valid birth events are not modified."""
+        deltas = PDPDeltas(
+            events=[
+                Event(
+                    id=-3,
+                    kind=EventKind.Birth,
+                    person=-2,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        _fix_birth_self_references(deltas)
+        assert deltas.events[0].person == -2
+        assert deltas.events[0].child == -1
+
+    def test_does_not_touch_non_birth_events(self):
+        """Shift events with person == child are not affected."""
+        deltas = PDPDeltas(
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Shift,
+                    person=-1,
+                    child=-1,
+                    description="Something",
+                    dateTime="2020-01-01",
+                )
+            ],
+        )
+        _fix_birth_self_references(deltas)
+        assert deltas.events[0].person == -1
+        assert deltas.events[0].child == -1
+
+    def test_fixes_adopted_event_too(self):
+        """Adopted events also get self-reference fix."""
+        deltas = PDPDeltas(
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Adopted,
+                    person=-1,
+                    child=-1,
+                    description="Adopted",
+                    dateTime="2000-01-01",
+                )
+            ],
+        )
+        _fix_birth_self_references(deltas)
+        assert deltas.events[0].person is None
+        assert deltas.events[0].child == -1
+
+
+class TestBirthEventEndToEnd:
+    """End-to-end tests ensuring birth events flow correctly through the pipeline."""
+
+    def test_birth_event_commit_with_child_only(self):
+        """Birth event with only child set commits correctly and infers parents."""
+        pdp = PDP(
+            people=[Person(id=-1, name="Barbara", gender="female")],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Birth,
+                    person=None,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                )
+            ],
+        )
+        diagram_data = DiagramData(pdp=pdp)
+        diagram_data.commit_pdp_items([-2])
+
+        # Barbara should be committed
+        committed_names = [p["name"] for p in diagram_data.people]
+        assert "Barbara" in committed_names
+
+        # The birth event's child should reference Barbara
+        birth_event = diagram_data.events[0]
+        assert birth_event["child"] is not None
+
+    def test_apply_deltas_preserves_correct_birth_semantics(self):
+        """apply_deltas correctly adds birth events with child-centric semantics."""
+        pdp = PDP()
+        deltas = PDPDeltas(
+            people=[Person(id=-1, name="Barbara", gender="female", confidence=0.9)],
+            events=[
+                Event(
+                    id=-2,
+                    kind=EventKind.Birth,
+                    person=None,
+                    child=-1,
+                    description="Born",
+                    dateTime="1953-01-01",
+                    confidence=0.8,
+                )
+            ],
+        )
+        new_pdp = apply_deltas(pdp, deltas)
+
+        assert len(new_pdp.events) == 1
+        birth = new_pdp.events[0]
+        assert birth.child == -1
+        assert birth.person is None
+        assert birth.kind == EventKind.Birth

--- a/btcopilot/tests/personal/test_extract_full.py
+++ b/btcopilot/tests/personal/test_extract_full.py
@@ -12,7 +12,7 @@ def test_extract_full_returns_pdp(discussion):
             Event(
                 id=-2,
                 kind=EventKind.Birth,
-                person=-1,
+                person=None,
                 child=-1,
                 description="Born",
                 dateTime="1953-01-01",


### PR DESCRIPTION
## Summary

- **Fixed extraction prompt**: Birth events now correctly use `child` = who was born, `person` = optional parent (null if unknown). Previously the prompt instructed `person = who was BORN, child = same ID`, creating self-referential links.
- **Added sanitization layer**: `_fix_birth_self_references()` automatically corrects LLM output where `person == child` on birth/adopted events before validation.
- **Added validation guard**: `validate_pdp_deltas()` now rejects birth/adopted events where `child == person` or `child == spouse` with a clear error message.
- **12 regression tests**: Covering validation rejection, sanitization fixes, correct semantics acceptance, and end-to-end commit flow.

## Test plan

- [x] All 12 new tests in `test_birth_self_reference.py` pass
- [x] Full personal test suite passes (79 tests, 0 failures)
- [x] Existing `test_extract_full.py` updated to use correct birth semantics
- [ ] Verify extraction on real discussions produces `person=null, child=<born person>` for birth events

Closes patrickkidd/theapp#77

🤖 Generated with [Claude Code](https://claude.com/claude-code)