### PR TITLE
Add per-entity-type F1 breakdown to eval harness

### DIFF
--- a/btcopilot/tests/training/test_eval_harness.py
+++ b/btcopilot/tests/training/test_eval_harness.py
@@ -1,0 +1,314 @@
+"""Tests for the extraction evaluation harness per-entity-type F1 breakdown."""
+
+import json
+
+import pytest
+
+from btcopilot.training.f1_metrics import F1Metrics, CumulativeF1Metrics
+from btcopilot.training.eval_harness import (
+    build_eval_result,
+    format_table,
+    format_json,
+    EvalResult,
+    DiscussionEvalResult,
+    EntityTypeBreakdown,
+    AggregateBreakdown,
+)
+
+
+def _make_cumulative(
+    disc_id: int,
+    people_tp=2,
+    people_fp=1,
+    people_fn=0,
+    events_tp=3,
+    events_fp=2,
+    events_fn=1,
+    bonds_tp=0,
+    bonds_fp=0,
+    bonds_fn=1,
+    summary="Test discussion",
+) -> CumulativeF1Metrics:
+    """Helper to build a CumulativeF1Metrics with known counts."""
+
+    def _f1(tp, fp, fn):
+        p = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        r = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1 = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+        return F1Metrics(tp=tp, fp=fp, fn=fn, precision=p, recall=r, f1=f1)
+
+    people_m = _f1(people_tp, people_fp, people_fn)
+    events_m = _f1(events_tp, events_fp, events_fn)
+    bonds_m = _f1(bonds_tp, bonds_fp, bonds_fn)
+
+    total_tp = people_tp + events_tp + bonds_tp
+    total_fp = people_fp + events_fp + bonds_fp
+    total_fn = people_fn + events_fn + bonds_fn
+    agg = _f1(total_tp, total_fp, total_fn)
+
+    return CumulativeF1Metrics(
+        discussion_id=disc_id,
+        discussion_summary=summary,
+        auditor_id="test@example.com",
+        aggregate_micro_f1=agg.f1,
+        people_f1=people_m.f1,
+        events_f1=events_m.f1,
+        pair_bonds_f1=bonds_m.f1,
+        people_metrics=people_m,
+        events_metrics=events_m,
+        pair_bonds_metrics=bonds_m,
+        ai_people_count=people_tp + people_fp,
+        ai_events_count=events_tp + events_fp,
+        gt_people_count=people_tp + people_fn,
+        gt_events_count=events_tp + events_fn,
+    )
+
+
+class TestBuildEvalResult:
+    """Tests for build_eval_result()."""
+
+    def test_empty_input(self):
+        result = build_eval_result([])
+        assert result.discussion_count == 0
+        assert result.per_discussion == []
+        assert result.aggregate == []
+
+    def test_single_discussion(self):
+        m = _make_cumulative(50, people_tp=3, people_fp=1, people_fn=0)
+        result = build_eval_result([m])
+
+        assert result.discussion_count == 1
+        assert len(result.per_discussion) == 1
+        assert len(result.aggregate) == 3
+
+        disc = result.per_discussion[0]
+        assert disc.discussion_id == 50
+        assert len(disc.entity_types) == 3
+
+        # Verify entity type names
+        names = [e.entity_type for e in disc.entity_types]
+        assert names == ["People", "Events", "PairBonds"]
+
+    def test_multiple_discussions(self):
+        metrics = [
+            _make_cumulative(50, people_tp=2, people_fp=1, people_fn=0),
+            _make_cumulative(51, people_tp=4, people_fp=0, people_fn=1),
+        ]
+        result = build_eval_result(metrics)
+
+        assert result.discussion_count == 2
+        assert len(result.per_discussion) == 2
+
+        # Check aggregate People TP is sum
+        people_agg = result.aggregate[0]
+        assert people_agg.entity_type == "People"
+        assert people_agg.total_tp == 6  # 2 + 4
+        assert people_agg.total_fp == 1  # 1 + 0
+        assert people_agg.total_fn == 1  # 0 + 1
+
+    def test_per_discussion_entity_counts(self):
+        m = _make_cumulative(
+            50,
+            people_tp=3,
+            people_fp=1,
+            people_fn=2,
+            events_tp=5,
+            events_fp=0,
+            events_fn=3,
+        )
+        result = build_eval_result([m])
+        disc = result.per_discussion[0]
+
+        people = disc.entity_types[0]
+        assert people.tp == 3
+        assert people.fp == 1
+        assert people.fn == 2
+        assert people.ai_count == 4  # tp + fp
+        assert people.gt_count == 5  # tp + fn
+
+        events = disc.entity_types[1]
+        assert events.tp == 5
+        assert events.fp == 0
+        assert events.fn == 3
+
+    def test_aggregate_micro_f1(self):
+        """Micro F1 should be computed from pooled TP/FP/FN, not averaged."""
+        metrics = [
+            _make_cumulative(50, people_tp=5, people_fp=0, people_fn=0),
+            _make_cumulative(51, people_tp=0, people_fp=5, people_fn=5),
+        ]
+        result = build_eval_result(metrics)
+
+        people_agg = result.aggregate[0]
+        # Pooled: TP=5, FP=5, FN=5 → P=0.5, R=0.5, F1=0.5
+        assert people_agg.total_tp == 5
+        assert people_agg.total_fp == 5
+        assert people_agg.total_fn == 5
+        assert abs(people_agg.micro_f1 - 0.5) < 0.001
+
+        # Avg F1: (1.0 + 0.0) / 2 = 0.5 — same in this case
+        assert abs(people_agg.avg_f1 - 0.5) < 0.001
+
+
+class TestFormatJson:
+    """Tests for format_json() output schema."""
+
+    def test_json_schema_keys(self):
+        m = _make_cumulative(50)
+        result = build_eval_result([m])
+        output = format_json(result)
+
+        # Top-level keys
+        assert "discussion_count" in output
+        assert "aggregate_f1" in output
+        assert "aggregate" in output
+        assert "per_discussion" in output
+
+    def test_json_aggregate_schema(self):
+        m = _make_cumulative(50)
+        result = build_eval_result([m])
+        output = format_json(result)
+
+        assert len(output["aggregate"]) == 3
+        for agg in output["aggregate"]:
+            assert "entity_type" in agg
+            assert "avg_f1" in agg
+            assert "micro_f1" in agg
+            assert "micro_precision" in agg
+            assert "micro_recall" in agg
+            assert "total_tp" in agg
+            assert "total_fp" in agg
+            assert "total_fn" in agg
+
+        entity_types = [a["entity_type"] for a in output["aggregate"]]
+        assert entity_types == ["People", "Events", "PairBonds"]
+
+    def test_json_per_discussion_schema(self):
+        m = _make_cumulative(50)
+        result = build_eval_result([m])
+        output = format_json(result)
+
+        assert len(output["per_discussion"]) == 1
+        disc = output["per_discussion"][0]
+        assert "discussion_id" in disc
+        assert "summary" in disc
+        assert "auditor_id" in disc
+        assert "aggregate_f1" in disc
+        assert "entity_types" in disc
+        assert len(disc["entity_types"]) == 3
+
+        for et in disc["entity_types"]:
+            assert "entity_type" in et
+            assert "f1" in et
+            assert "precision" in et
+            assert "recall" in et
+            assert "tp" in et
+            assert "fp" in et
+            assert "fn" in et
+            assert "ai_count" in et
+            assert "gt_count" in et
+
+    def test_json_serializable(self):
+        """Ensure output can be serialized to JSON without errors."""
+        metrics = [_make_cumulative(50), _make_cumulative(51)]
+        result = build_eval_result(metrics)
+        output = format_json(result)
+
+        # Should not raise
+        json_str = json.dumps(output)
+        parsed = json.loads(json_str)
+        assert parsed["discussion_count"] == 2
+
+    def test_json_values_match_input(self):
+        m = _make_cumulative(
+            50, people_tp=4, people_fp=1, people_fn=2, events_tp=6, events_fp=0, events_fn=3
+        )
+        result = build_eval_result([m])
+        output = format_json(result)
+
+        disc = output["per_discussion"][0]
+        people = disc["entity_types"][0]
+        assert people["entity_type"] == "People"
+        assert people["tp"] == 4
+        assert people["fp"] == 1
+        assert people["fn"] == 2
+
+        events = disc["entity_types"][1]
+        assert events["entity_type"] == "Events"
+        assert events["tp"] == 6
+        assert events["fp"] == 0
+        assert events["fn"] == 3
+
+    def test_empty_result_json(self):
+        result = build_eval_result([])
+        output = format_json(result)
+        assert output["discussion_count"] == 0
+        assert output["per_discussion"] == []
+        assert output["aggregate"] == []
+
+
+class TestFormatTable:
+    """Tests for format_table() human-readable output."""
+
+    def test_table_contains_entity_types(self):
+        m = _make_cumulative(50)
+        result = build_eval_result([m])
+        table = format_table(result)
+
+        assert "People" in table
+        assert "Events" in table
+        assert "PairBonds" in table
+
+    def test_table_contains_discussion_id(self):
+        m = _make_cumulative(50, summary="Test family")
+        result = build_eval_result([m])
+        table = format_table(result)
+
+        assert "Discussion 50" in table
+        assert "Test family" in table
+
+    def test_table_contains_aggregate_section(self):
+        m = _make_cumulative(50)
+        result = build_eval_result([m])
+        table = format_table(result)
+
+        assert "AGGREGATE" in table
+
+    def test_table_contains_pass_fail(self):
+        m = _make_cumulative(50, people_tp=10, people_fp=0, people_fn=0)
+        result = build_eval_result([m])
+        table = format_table(result)
+
+        # People F1 = 1.0 > 0.7, so should PASS
+        assert "PASS" in table
+
+    def test_table_empty_result(self):
+        result = build_eval_result([])
+        table = format_table(result)
+        assert "No discussions" in table
+
+    def test_table_multiple_discussions(self):
+        metrics = [
+            _make_cumulative(50, summary="Family A"),
+            _make_cumulative(51, summary="Family B"),
+        ]
+        result = build_eval_result(metrics)
+        table = format_table(result)
+
+        assert "Discussion 50" in table
+        assert "Discussion 51" in table
+        assert "Family A" in table
+        assert "Family B" in table
+        assert "2 discussions" in table
+
+    def test_table_contains_header_columns(self):
+        m = _make_cumulative(50)
+        result = build_eval_result([m])
+        table = format_table(result)
+
+        assert "F1" in table
+        assert "Prec" in table
+        assert "Rec" in table
+        assert "TP" in table
+        assert "FP" in table
+        assert "FN" in table

--- a/btcopilot/training/eval_harness.py
+++ b/btcopilot/training/eval_harness.py
@@ -1,0 +1,337 @@
+"""
+Extraction evaluation harness — per-entity-type F1 breakdown.
+
+Provides structured evaluation results with per-entity-type F1 (People, Events,
+PairBonds) reported both per-discussion and as aggregate across all GT discussions.
+
+Output formats:
+  - Human-readable: formatted table via format_table()
+  - Machine-readable: JSON via format_json()
+
+Usage (standalone):
+    uv run python -m btcopilot.training.eval_harness
+    uv run python -m btcopilot.training.eval_harness --json
+    uv run python -m btcopilot.training.eval_harness --ids 50 51 52
+"""
+
+import json
+from dataclasses import dataclass, field, asdict
+
+from btcopilot.training.f1_metrics import (
+    F1Metrics,
+    CumulativeF1Metrics,
+    calculate_cumulative_f1,
+    calculate_all_cumulative_f1,
+)
+
+# Targets from MVP_DASHBOARD.md
+TARGET_PEOPLE_F1 = 0.7
+TARGET_EVENTS_F1 = 0.3
+
+
+@dataclass
+class EntityTypeBreakdown:
+    """F1 metrics for a single entity type."""
+
+    entity_type: str
+    f1: float = 0.0
+    precision: float = 0.0
+    recall: float = 0.0
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    ai_count: int = 0
+    gt_count: int = 0
+
+
+@dataclass
+class DiscussionEvalResult:
+    """Per-discussion evaluation with per-entity-type breakdown."""
+
+    discussion_id: int
+    summary: str = ""
+    auditor_id: str = ""
+    aggregate_f1: float = 0.0
+    entity_types: list[EntityTypeBreakdown] = field(default_factory=list)
+
+
+@dataclass
+class AggregateBreakdown:
+    """Aggregate F1 across all discussions for a single entity type."""
+
+    entity_type: str
+    avg_f1: float = 0.0
+    total_tp: int = 0
+    total_fp: int = 0
+    total_fn: int = 0
+    micro_f1: float = 0.0
+    micro_precision: float = 0.0
+    micro_recall: float = 0.0
+
+
+@dataclass
+class EvalResult:
+    """Full evaluation result: per-discussion + aggregate breakdowns."""
+
+    discussion_count: int = 0
+    per_discussion: list[DiscussionEvalResult] = field(default_factory=list)
+    aggregate: list[AggregateBreakdown] = field(default_factory=list)
+    aggregate_f1: float = 0.0
+
+
+def _metrics_to_breakdown(
+    entity_type: str, metrics: F1Metrics, ai_count: int = 0, gt_count: int = 0
+) -> EntityTypeBreakdown:
+    return EntityTypeBreakdown(
+        entity_type=entity_type,
+        f1=metrics.f1,
+        precision=metrics.precision,
+        recall=metrics.recall,
+        tp=metrics.tp,
+        fp=metrics.fp,
+        fn=metrics.fn,
+        ai_count=ai_count,
+        gt_count=gt_count,
+    )
+
+
+def _cumulative_to_discussion_result(m: CumulativeF1Metrics) -> DiscussionEvalResult:
+    return DiscussionEvalResult(
+        discussion_id=m.discussion_id,
+        summary=m.discussion_summary,
+        auditor_id=m.auditor_id,
+        aggregate_f1=m.aggregate_micro_f1,
+        entity_types=[
+            _metrics_to_breakdown(
+                "People", m.people_metrics, m.ai_people_count, m.gt_people_count
+            ),
+            _metrics_to_breakdown(
+                "Events", m.events_metrics, m.ai_events_count, m.gt_events_count
+            ),
+            _metrics_to_breakdown(
+                "PairBonds",
+                m.pair_bonds_metrics,
+                m.pair_bonds_metrics.tp + m.pair_bonds_metrics.fp,
+                m.pair_bonds_metrics.tp + m.pair_bonds_metrics.fn,
+            ),
+        ],
+    )
+
+
+def _safe_div(num: float, den: float) -> float:
+    return num / den if den > 0 else 0.0
+
+
+def _calc_micro_f1(tp: int, fp: int, fn: int) -> tuple[float, float, float]:
+    """Returns (precision, recall, f1)."""
+    precision = _safe_div(tp, tp + fp)
+    recall = _safe_div(tp, tp + fn)
+    f1 = _safe_div(2 * precision * recall, precision + recall)
+    return precision, recall, f1
+
+
+def build_eval_result(cumulative_metrics: list[CumulativeF1Metrics]) -> EvalResult:
+    """Build a structured EvalResult from cumulative F1 metrics."""
+    per_disc = [_cumulative_to_discussion_result(m) for m in cumulative_metrics]
+
+    n = len(per_disc)
+    if n == 0:
+        return EvalResult()
+
+    # Build aggregate per entity type
+    entity_names = ["People", "Events", "PairBonds"]
+    aggregates = []
+    for i, name in enumerate(entity_names):
+        total_tp = sum(d.entity_types[i].tp for d in per_disc)
+        total_fp = sum(d.entity_types[i].fp for d in per_disc)
+        total_fn = sum(d.entity_types[i].fn for d in per_disc)
+        avg_f1 = sum(d.entity_types[i].f1 for d in per_disc) / n
+        micro_p, micro_r, micro_f1 = _calc_micro_f1(total_tp, total_fp, total_fn)
+        aggregates.append(
+            AggregateBreakdown(
+                entity_type=name,
+                avg_f1=avg_f1,
+                total_tp=total_tp,
+                total_fp=total_fp,
+                total_fn=total_fn,
+                micro_f1=micro_f1,
+                micro_precision=micro_p,
+                micro_recall=micro_r,
+            )
+        )
+
+    all_tp = sum(a.total_tp for a in aggregates)
+    all_fp = sum(a.total_fp for a in aggregates)
+    all_fn = sum(a.total_fn for a in aggregates)
+    _, _, agg_f1 = _calc_micro_f1(all_tp, all_fp, all_fn)
+
+    return EvalResult(
+        discussion_count=n,
+        per_discussion=per_disc,
+        aggregate=aggregates,
+        aggregate_f1=agg_f1,
+    )
+
+
+def format_table(result: EvalResult) -> str:
+    """Format evaluation result as a human-readable table."""
+    if result.discussion_count == 0:
+        return "No discussions evaluated."
+
+    lines = []
+    lines.append("=" * 80)
+    lines.append(
+        f"EXTRACTION EVALUATION — Per-Entity-Type F1 ({result.discussion_count} discussions)"
+    )
+    lines.append(
+        f"Targets: People F1 > {TARGET_PEOPLE_F1}, Events F1 > {TARGET_EVENTS_F1}"
+    )
+    lines.append("=" * 80)
+    lines.append("")
+
+    # Per-discussion tables
+    for d in result.per_discussion:
+        lines.append(f"Discussion {d.discussion_id}: {d.summary}")
+        lines.append(f"  Auditor: {d.auditor_id}")
+        lines.append(
+            f"  {'Entity Type':<12} {'F1':>6} {'Prec':>6} {'Rec':>6} "
+            f"{'TP':>4} {'FP':>4} {'FN':>4} {'AI#':>4} {'GT#':>4}"
+        )
+        lines.append(f"  {'-' * 62}")
+        for e in d.entity_types:
+            lines.append(
+                f"  {e.entity_type:<12} {e.f1:>6.3f} {e.precision:>6.3f} {e.recall:>6.3f} "
+                f"{e.tp:>4} {e.fp:>4} {e.fn:>4} {e.ai_count:>4} {e.gt_count:>4}"
+            )
+        lines.append(f"  {'Aggregate':<12} {d.aggregate_f1:>6.3f}")
+        lines.append("")
+
+    # Aggregate table
+    lines.append("-" * 80)
+    lines.append(f"AGGREGATE ({result.discussion_count} discussions)")
+    lines.append(
+        f"  {'Entity Type':<12} {'Avg F1':>7} {'Micro F1':>9} {'Micro P':>8} "
+        f"{'Micro R':>8} {'TP':>5} {'FP':>5} {'FN':>5}"
+    )
+    lines.append(f"  {'-' * 68}")
+    for a in result.aggregate:
+        target = ""
+        if a.entity_type == "People":
+            target = f"  {'PASS' if a.avg_f1 > TARGET_PEOPLE_F1 else 'FAIL'} (>{TARGET_PEOPLE_F1})"
+        elif a.entity_type == "Events":
+            target = f"  {'PASS' if a.avg_f1 > TARGET_EVENTS_F1 else 'FAIL'} (>{TARGET_EVENTS_F1})"
+        lines.append(
+            f"  {a.entity_type:<12} {a.avg_f1:>7.3f} {a.micro_f1:>9.3f} {a.micro_precision:>8.3f} "
+            f"{a.micro_recall:>8.3f} {a.total_tp:>5} {a.total_fp:>5} {a.total_fn:>5}{target}"
+        )
+    lines.append(f"  {'Overall':<12} {result.aggregate_f1:>7.3f}")
+    lines.append("=" * 80)
+
+    return "\n".join(lines)
+
+
+def format_json(result: EvalResult) -> dict:
+    """Format evaluation result as a machine-readable JSON-serializable dict.
+
+    Schema:
+    {
+        "discussion_count": int,
+        "aggregate_f1": float,
+        "aggregate": [
+            {
+                "entity_type": str,  // "People" | "Events" | "PairBonds"
+                "avg_f1": float,
+                "micro_f1": float,
+                "micro_precision": float,
+                "micro_recall": float,
+                "total_tp": int,
+                "total_fp": int,
+                "total_fn": int
+            }
+        ],
+        "per_discussion": [
+            {
+                "discussion_id": int,
+                "summary": str,
+                "auditor_id": str,
+                "aggregate_f1": float,
+                "entity_types": [
+                    {
+                        "entity_type": str,
+                        "f1": float,
+                        "precision": float,
+                        "recall": float,
+                        "tp": int,
+                        "fp": int,
+                        "fn": int,
+                        "ai_count": int,
+                        "gt_count": int
+                    }
+                ]
+            }
+        ]
+    }
+    """
+    return asdict(result)
+
+
+def run_eval(discussion_ids: list[int] | None = None) -> EvalResult:
+    """Run evaluation on specified discussions (or all with approved GT).
+
+    Must be called within a Flask app context.
+    """
+    if discussion_ids:
+        metrics = []
+        for disc_id in discussion_ids:
+            try:
+                m = calculate_cumulative_f1(disc_id)
+                metrics.append(m)
+            except ValueError:
+                continue
+    else:
+        system = calculate_all_cumulative_f1(include_synthetic=True)
+        metrics = system.per_discussion
+
+    return build_eval_result(metrics)
+
+
+def main():
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Extraction evaluation harness — per-entity-type F1 breakdown"
+    )
+    parser.add_argument(
+        "--ids", nargs="+", type=int, help="Discussion IDs to evaluate"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Output machine-readable JSON"
+    )
+    args = parser.parse_args()
+
+    from btcopilot.app import create_app
+
+    app = create_app()
+    with app.app_context():
+        result = run_eval(discussion_ids=args.ids)
+
+        if result.discussion_count == 0:
+            print("No discussions with approved GT found.")
+            sys.exit(1)
+
+        if args.json:
+            print(json.dumps(format_json(result), indent=2))
+        else:
+            print(format_table(result))
+            # Also print JSON to stderr for scripting
+            print(
+                "\n--- JSON output (use --json for clean JSON to stdout) ---",
+                file=sys.stderr,
+            )
+
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds new `btcopilot/training/eval_harness.py` module with per-entity-type F1 breakdown (People, Events, PairBonds) reported both per-discussion and as aggregate across all GT discussions
- Provides human-readable table output (`format_table()`) and machine-readable JSON output (`format_json()`)
- Runnable as CLI: `uv run python -m btcopilot.training.eval_harness [--json] [--ids 50 51 52]`
- 18 new tests verifying output schema, JSON serialization, aggregation math, and table formatting

Closes patrickkidd/theapp#79

## Test plan

- [x] All 18 new tests in `test_eval_harness.py` pass
- [x] Full test suite (575 tests) passes with no regressions
- [ ] Run `uv run python -m btcopilot.training.eval_harness` against live DB to verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)