### PR TITLE
Add integration tests for sync-prod-db.sh

### DIFF
--- a/btcopilot/tests/personal/test_sync_prod_db.py
+++ b/btcopilot/tests/personal/test_sync_prod_db.py
@@ -1,0 +1,252 @@
+"""
+Integration tests for scripts/sync-prod-db.sh
+
+Tests argument parsing, help output, error handling, and preflight checks.
+These tests do NOT require SSH access or Docker — they verify the script's
+behavior when prerequisites are missing or arguments are invalid.
+"""
+
+import os
+import subprocess
+import stat
+import textwrap
+
+import pytest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+SCRIPT_PATH = os.path.join(REPO_ROOT, "scripts", "sync-prod-db.sh")
+
+
+@pytest.fixture(autouse=True)
+def _check_script_exists():
+    if not os.path.isfile(SCRIPT_PATH):
+        pytest.skip("sync-prod-db.sh not present on this branch")
+
+
+def run_script(*args, timeout=10, input_text=None, env_override=None):
+    """Run the sync script with given arguments, return CompletedProcess."""
+    env = os.environ.copy()
+    if env_override:
+        env.update(env_override)
+    return subprocess.run(
+        ["/usr/bin/env", "bash", SCRIPT_PATH, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        input=input_text,
+        env=env,
+    )
+
+
+# ── Script basics ──────────────────────────────────────────────────────
+
+
+class TestScriptBasics:
+    """Verify the script file itself is well-formed."""
+
+    def test_script_exists(self):
+        assert os.path.isfile(SCRIPT_PATH)
+
+    def test_script_is_executable(self):
+        mode = os.stat(SCRIPT_PATH).st_mode
+        assert mode & stat.S_IXUSR, "Script should be executable by owner"
+
+    def test_script_has_bash_shebang(self):
+        with open(SCRIPT_PATH) as f:
+            first_line = f.readline().strip()
+        assert first_line == "#!/usr/bin/env bash"
+
+
+# ── Help / usage ───────────────────────────────────────────────────────
+
+
+class TestHelpOutput:
+    """--help and -h should print usage and exit 0."""
+
+    def test_help_flag(self):
+        result = run_script("--help")
+        assert result.returncode == 0
+        assert "Usage:" in result.stdout
+        assert "--dry-run" in result.stdout
+        assert "--dump-only" in result.stdout
+        assert "--restore" in result.stdout
+
+    def test_short_help_flag(self):
+        result = run_script("-h")
+        assert result.returncode == 0
+        assert "Usage:" in result.stdout
+
+    def test_help_mentions_backup_dir(self):
+        result = run_script("--help")
+        assert "backups" in result.stdout.lower()
+
+
+# ── Argument parsing ───────────────────────────────────────────────────
+
+
+class TestArgumentParsing:
+    """Verify the script rejects invalid arguments."""
+
+    def test_unknown_option_fails(self):
+        result = run_script("--nonexistent-flag")
+        assert result.returncode != 0
+        assert "Unknown option" in result.stderr
+
+    def test_multiple_unknown_options(self):
+        result = run_script("--foo", "--bar")
+        assert result.returncode != 0
+        assert "Unknown option" in result.stderr
+
+    def test_restore_without_file_arg_fails(self):
+        """--restore requires a file path argument."""
+        result = run_script("--restore")
+        # Should fail — either with 'Unknown option' on shift 2 failing
+        # or bash unbound variable error due to set -u
+        assert result.returncode != 0
+
+
+# ── Preflight checks ──────────────────────────────────────────────────
+
+
+class TestPreflightChecks:
+    """The script should fail gracefully when SSH or Docker aren't available."""
+
+    def test_dry_run_fails_without_ssh(self):
+        """--dry-run still requires SSH to show prod stats; should fail if
+        SSH to production is not configured in this environment."""
+        result = run_script("--dry-run", timeout=15)
+        # In CI or dev without SSH keys, check_ssh will die
+        # We just verify it doesn't hang and produces an error message
+        if result.returncode != 0:
+            assert "ERROR" in result.stderr or "SSH" in result.stderr or "ssh" in result.stdout.lower()
+
+    def test_full_sync_fails_without_ssh(self):
+        """Full sync (no flags) should fail on SSH preflight."""
+        result = run_script(timeout=15, input_text="n\n")
+        if result.returncode != 0:
+            output = result.stderr + result.stdout
+            assert "ERROR" in output or "SSH" in output or "ssh" in output.lower()
+
+
+# ── Restore mode ───────────────────────────────────────────────────────
+
+
+class TestRestoreMode:
+    """Test --restore flag behavior."""
+
+    def test_restore_nonexistent_file_fails(self):
+        """--restore with a missing file should fail with a clear error.
+
+        Note: --restore also checks local postgres first, so it may fail
+        on that check before reaching the file check. Both are valid failures.
+        """
+        result = run_script(
+            "--restore", "/tmp/nonexistent_dump_file_12345.pgdump",
+            input_text="y\n",
+            timeout=10,
+        )
+        assert result.returncode != 0
+        output = result.stderr + result.stdout
+        # Should mention either the missing file or missing Docker container
+        assert "ERROR" in output
+
+    def test_restore_requires_local_docker(self):
+        """--restore checks for local postgres container before anything else.
+
+        If Docker isn't running or the container doesn't exist, the script
+        should fail at check_local_postgres.
+        """
+        result = run_script(
+            "--restore", "/tmp/some_file.pgdump",
+            input_text="y\n",
+            timeout=10,
+        )
+        if result.returncode != 0:
+            output = result.stderr + result.stdout
+            assert "ERROR" in output
+
+
+# ── Script configuration ──────────────────────────────────────────────
+
+
+class TestScriptConfiguration:
+    """Verify the script contains expected configuration values."""
+
+    def test_config_references_correct_prod_host(self):
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert '107.170.236.117' in content
+
+    def test_config_references_correct_db_name(self):
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert 'familydiagram' in content
+
+    def test_config_references_backup_dir(self):
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert '.openclaw/backups' in content
+
+    def test_config_uses_custom_format_dump(self):
+        """pg_dump should use -Fc (custom format) for efficient dumps."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert 'pg_dump' in content
+        assert '-Fc' in content
+
+    def test_restore_uses_no_owner(self):
+        """pg_restore should use --no-owner to avoid permission issues."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert '--no-owner' in content
+
+    def test_restore_uses_no_privileges(self):
+        """pg_restore should use --no-privileges to avoid permission issues."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert '--no-privileges' in content
+
+    def test_script_uses_set_euo_pipefail(self):
+        """Script should use strict bash mode."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert 'set -euo pipefail' in content
+
+
+# ── Safety checks ─────────────────────────────────────────────────────
+
+
+class TestSafetyChecks:
+    """Verify the script has appropriate safety mechanisms."""
+
+    def test_script_backs_up_before_restore(self):
+        """The script should call backup_local before restore_to_local."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        # In both restore-only and full-sync paths, backup comes before restore
+        backup_pos = content.index('backup_local')
+        restore_pos = content.index('restore_to_local')
+        assert backup_pos < restore_pos, "backup_local should be called before restore_to_local"
+
+    def test_script_requires_confirmation(self):
+        """The script should prompt for confirmation before destructive operations."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert 'read -rp' in content
+        assert 'Continue?' in content
+
+    def test_script_terminates_connections_before_drop(self):
+        """Before dropping the DB, the script should terminate active connections."""
+        with open(SCRIPT_PATH) as f:
+            content = f.read()
+        assert 'pg_terminate_backend' in content
+
+    def test_full_sync_aborts_on_no_confirmation(self):
+        """Answering 'n' to confirmation should abort without error."""
+        # This will fail at SSH check first in most environments,
+        # but if SSH is available, it should abort on 'n'
+        result = run_script(input_text="n\n", timeout=15)
+        # Either fails at SSH (exit != 0) or aborts cleanly (exit 0)
+        # We just verify it doesn't hang
+        assert result.returncode is not None

--- a/scripts/sync-prod-db.sh
+++ b/scripts/sync-prod-db.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+#
+# sync-prod-db.sh — Pull production database to local Docker postgres
+#
+# Usage:
+#   ./scripts/sync-prod-db.sh              # Full sync (with confirmation)
+#   ./scripts/sync-prod-db.sh --dry-run    # Show what would happen
+#   ./scripts/sync-prod-db.sh --dump-only  # Download dump but don't restore
+#   ./scripts/sync-prod-db.sh --restore <file>  # Restore from existing dump
+#
+# Prerequisites:
+#   - SSH access to production server (root@107.170.236.117)
+#   - Local Docker postgres running (fd-postgres container)
+#
+
+set -euo pipefail
+
+# ── Config ──────────────────────────────────────────────────────────────────
+
+PROD_HOST="107.170.236.117"
+PROD_USER="root"
+PROD_CONTAINER="fd-postgres"
+PROD_DB_USER="familydiagram"
+PROD_DB_NAME="familydiagram"
+
+LOCAL_CONTAINER="fd-postgres"
+LOCAL_DB_USER="familydiagram"
+LOCAL_DB_NAME="familydiagram"
+
+BACKUP_DIR="${HOME}/.openclaw/backups"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DUMP_FILE="${BACKUP_DIR}/prod_${TIMESTAMP}.pgdump"
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+red()    { printf '\033[0;31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[0;32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[0;33m%s\033[0m\n' "$*"; }
+bold()   { printf '\033[1m%s\033[0m\n' "$*"; }
+
+die() { red "ERROR: $*" >&2; exit 1; }
+
+check_local_postgres() {
+    if ! docker ps --format '{{.Names}}' | grep -q "^${LOCAL_CONTAINER}$"; then
+        die "Local container '${LOCAL_CONTAINER}' is not running. Start it with: docker compose up fd-postgres -d"
+    fi
+    green "✓ Local postgres container is running"
+}
+
+check_ssh() {
+    if ! ssh -o ConnectTimeout=5 -o BatchMode=yes "${PROD_USER}@${PROD_HOST}" "echo ok" &>/dev/null; then
+        die "Cannot SSH to ${PROD_USER}@${PROD_HOST}. Check your SSH keys."
+    fi
+    green "✓ SSH connection to production OK"
+}
+
+check_prod_postgres() {
+    if ! ssh "${PROD_USER}@${PROD_HOST}" "docker exec ${PROD_CONTAINER} pg_isready -U ${PROD_DB_USER}" &>/dev/null; then
+        die "Production postgres is not ready"
+    fi
+    green "✓ Production postgres is ready"
+}
+
+show_prod_stats() {
+    bold "Production database stats:"
+    ssh "${PROD_USER}@${PROD_HOST}" "docker exec ${PROD_CONTAINER} psql -U ${PROD_DB_USER} -d ${PROD_DB_NAME} -c \"
+        SELECT schemaname, relname AS table, n_live_tup AS row_count
+        FROM pg_stat_user_tables
+        ORDER BY n_live_tup DESC
+        LIMIT 15;
+    \""
+}
+
+show_local_stats() {
+    bold "Local database stats:"
+    docker exec "${LOCAL_CONTAINER}" psql -U "${LOCAL_DB_USER}" -d "${LOCAL_DB_NAME}" -c "
+        SELECT schemaname, relname AS table, n_live_tup AS row_count
+        FROM pg_stat_user_tables
+        ORDER BY n_live_tup DESC
+        LIMIT 15;
+    "
+}
+
+dump_prod() {
+    mkdir -p "${BACKUP_DIR}"
+    bold "Dumping production database..."
+    yellow "  → ${DUMP_FILE}"
+
+    ssh "${PROD_USER}@${PROD_HOST}" \
+        "docker exec ${PROD_CONTAINER} pg_dump -U ${PROD_DB_USER} -Fc ${PROD_DB_NAME}" \
+        > "${DUMP_FILE}"
+
+    local size
+    size=$(du -h "${DUMP_FILE}" | cut -f1)
+    green "✓ Dump complete (${size})"
+}
+
+backup_local() {
+    local backup="${BACKUP_DIR}/local_backup_${TIMESTAMP}.pgdump"
+    bold "Backing up local database first..."
+    yellow "  → ${backup}"
+
+    docker exec "${LOCAL_CONTAINER}" \
+        pg_dump -U "${LOCAL_DB_USER}" -Fc "${LOCAL_DB_NAME}" \
+        > "${backup}"
+
+    local size
+    size=$(du -h "${backup}" | cut -f1)
+    green "✓ Local backup saved (${size})"
+}
+
+restore_to_local() {
+    local dump_path="$1"
+
+    if [ ! -f "${dump_path}" ]; then
+        die "Dump file not found: ${dump_path}"
+    fi
+
+    bold "Restoring to local database..."
+    yellow "  ← ${dump_path}"
+
+    # Drop and recreate database
+    docker exec "${LOCAL_CONTAINER}" psql -U "${LOCAL_DB_USER}" -d postgres -c "
+        SELECT pg_terminate_backend(pid)
+        FROM pg_stat_activity
+        WHERE datname = '${LOCAL_DB_NAME}' AND pid <> pg_backend_pid();
+    " &>/dev/null || true
+
+    docker exec "${LOCAL_CONTAINER}" dropdb -U "${LOCAL_DB_USER}" --if-exists "${LOCAL_DB_NAME}"
+    docker exec "${LOCAL_CONTAINER}" createdb -U "${LOCAL_DB_USER}" "${LOCAL_DB_NAME}"
+
+    # Restore
+    docker exec -i "${LOCAL_CONTAINER}" \
+        pg_restore -U "${LOCAL_DB_USER}" -d "${LOCAL_DB_NAME}" --no-owner --no-privileges \
+        < "${dump_path}" || true
+    # pg_restore returns non-zero on warnings (e.g., missing extensions), which is OK
+
+    green "✓ Restore complete"
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Pull production database to local Docker postgres for testing.
+
+Options:
+  --dry-run         Show what would happen without doing it
+  --dump-only       Download dump file but don't restore locally
+  --restore <file>  Restore from an existing dump file (skip SSH)
+  -h, --help        Show this help
+
+Backups are stored in: ${BACKUP_DIR}/
+EOF
+}
+
+main() {
+    local dry_run=false
+    local dump_only=false
+    local restore_file=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)    dry_run=true; shift ;;
+            --dump-only)  dump_only=true; shift ;;
+            --restore)    restore_file="$2"; shift 2 ;;
+            -h|--help)    usage; exit 0 ;;
+            *)            die "Unknown option: $1" ;;
+        esac
+    done
+
+    bold "═══════════════════════════════════════"
+    bold "  Production → Local Database Sync"
+    bold "═══════════════════════════════════════"
+    echo
+
+    # ── Restore-only mode ──
+    if [[ -n "${restore_file}" ]]; then
+        check_local_postgres
+        echo
+        yellow "Restoring from: ${restore_file}"
+        yellow "This will DESTROY the local '${LOCAL_DB_NAME}' database and replace it."
+        echo
+        read -rp "Continue? [y/N] " confirm
+        [[ "${confirm}" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+        echo
+        backup_local
+        restore_to_local "${restore_file}"
+        echo
+        show_local_stats
+        echo
+        green "Done. Restart the Flask server to pick up the new data."
+        exit 0
+    fi
+
+    # ── Preflight checks ──
+    bold "Preflight checks..."
+    if [[ "${dry_run}" == true ]]; then
+        yellow "(DRY RUN — no changes will be made)"
+        echo
+    fi
+
+    check_ssh
+    check_prod_postgres
+
+    if [[ "${dump_only}" == false ]]; then
+        check_local_postgres
+    fi
+    echo
+
+    # ── Show prod stats ──
+    show_prod_stats
+    echo
+
+    if [[ "${dry_run}" == true ]]; then
+        yellow "DRY RUN complete. Would do:"
+        echo "  1. pg_dump from ${PROD_HOST}:${PROD_CONTAINER} → ${DUMP_FILE}"
+        if [[ "${dump_only}" == false ]]; then
+            echo "  2. Backup local DB → ${BACKUP_DIR}/local_backup_${TIMESTAMP}.pgdump"
+            echo "  3. Drop & recreate local '${LOCAL_DB_NAME}'"
+            echo "  4. pg_restore dump into local"
+        fi
+        exit 0
+    fi
+
+    # ── Confirmation ──
+    if [[ "${dump_only}" == false ]]; then
+        echo
+        yellow "This will:"
+        echo "  1. Download production database dump"
+        echo "  2. DESTROY the local '${LOCAL_DB_NAME}' database"
+        echo "  3. Replace it with production data"
+        echo
+        read -rp "Continue? [y/N] " confirm
+        [[ "${confirm}" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+        echo
+    fi
+
+    # ── Execute ──
+    dump_prod
+
+    if [[ "${dump_only}" == true ]]; then
+        echo
+        green "Dump saved to: ${DUMP_FILE}"
+        echo "To restore later: $(basename "$0") --restore ${DUMP_FILE}"
+        exit 0
+    fi
+
+    echo
+    backup_local
+    echo
+    restore_to_local "${DUMP_FILE}"
+    echo
+    show_local_stats
+    echo
+    green "Done. Restart the Flask server to pick up the new data."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds 24 integration tests for `scripts/sync-prod-db.sh` (introduced in PR #90)
- Tests cover: script basics, help output, argument parsing, preflight checks, restore mode, configuration validation, and safety mechanisms
- All tests run without SSH or Docker by verifying error handling paths and script content

## Test categories
- **Script basics**: file exists, executable, bash shebang
- **Help output**: `--help`, `-h` flags, content verification
- **Argument parsing**: unknown options rejected, `--restore` without file fails
- **Preflight checks**: SSH/Docker failure handling
- **Restore mode**: nonexistent file handling, Docker dependency check
- **Configuration**: correct prod host, DB name, backup dir, pg_dump flags
- **Safety**: backup-before-restore ordering, confirmation prompts, connection termination

## Test plan
- [x] `uv run pytest btcopilot/tests/personal/test_sync_prod_db.py -v` — 24 passed
- [x] `uv run pytest btcopilot/tests/personal/ -x` — 75 passed, 4 skipped (no regressions)

Closes patrickkidd/theapp#92

🤖 Generated with [Claude Code](https://claude.com/claude-code)