### PR TITLE
Fix CI: mock gemini_structured in extraction tests

### DIFF
--- a/btcopilot/tests/personal/test_e2e_synthetic.py
+++ b/btcopilot/tests/personal/test_e2e_synthetic.py
@@ -125,6 +125,9 @@ def test_e2e_chat_then_extract(test_user, diagram_with_discussion):
     with patch(
         "btcopilot.pdp._extract_and_validate",
         AsyncMock(return_value=(CACHED_PDP, CACHED_DELTAS)),
+    ), patch(
+        "btcopilot.pdp.gemini_structured",
+        AsyncMock(return_value=PDPDeltas()),
     ):
         from btcopilot.pdp import extract_full
 

--- a/btcopilot/tests/personal/test_extract_full.py
+++ b/btcopilot/tests/personal/test_extract_full.py
@@ -49,7 +49,10 @@ def test_extract_full_returns_merged_pdp(discussion):
     with patch(
         "btcopilot.pdp._extract_and_validate",
         AsyncMock(side_effect=[(pass1_pdp, pass1_deltas), (pass2_pdp, pass2_deltas)]),
-    ) as mock_extract:
+    ) as mock_extract, patch(
+        "btcopilot.pdp.gemini_structured",
+        AsyncMock(return_value=PDPDeltas()),
+    ):
         from btcopilot.pdp import extract_full
 
         diagram_data = DiagramData()


### PR DESCRIPTION
## Summary

- The 3-pass SARF review architecture (304c9c6) added a relationship review pass in `_two_pass_extract` that calls `gemini_structured` directly, bypassing the existing `_extract_and_validate` mock
- Two tests (`test_extract_full_returns_merged_pdp`, `test_e2e_chat_then_extract`) use test data with Shift events, triggering pass 3 which tries to create a real Gemini client and fails with `KeyError: 'GOOGLE_GEMINI_API_KEY'` in CI
- Added `btcopilot.pdp.gemini_structured` mock (returning empty `PDPDeltas`) alongside the existing `_extract_and_validate` mock in both tests

## Test plan

- [x] Both previously-failing tests pass locally
- [x] All 8 tests in the two affected files pass
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)