### PR TITLE
Add model-specific conversational prompt system for Opus vs Gemini

### DIFF
--- a/btcopilot/llmutil.py
+++ b/btcopilot/llmutil.py
@@ -249,6 +249,7 @@ async def claude_text(prompt=None, **kwargs):
     """Generate unstructured text using Claude (Anthropic API).
 
     Accepts the same interface as gemini_text():
+      - model: str — Claude model identifier (default: RESPONSE_MODEL)
       - system_instruction: str — system prompt
       - turns: list of (role, text) tuples — "user"/"model" mapped to "user"/"assistant"
       - temperature: float (ignored when thinking is enabled — API forces 1.0)
@@ -259,6 +260,7 @@ async def claude_text(prompt=None, **kwargs):
     This forces temperature=1.0 per Anthropic API constraints.
     """
     start_time = time.time()
+    model = kwargs.get("model", RESPONSE_MODEL)
     max_output_tokens = kwargs.get("max_output_tokens", 8192)
     system_instruction = kwargs.get("system_instruction")
 
@@ -268,7 +270,7 @@ async def claude_text(prompt=None, **kwargs):
 
     client = _anthropic_client()
     api_kwargs = {
-        "model": RESPONSE_MODEL,
+        "model": model,
         "max_tokens": max_output_tokens,
         "messages": messages,
         "thinking": {
@@ -293,21 +295,22 @@ def claude_text_sync(prompt=None, **kwargs):
     return asyncio.run(claude_text(prompt, **kwargs))
 
 
-# --- Unified response text API (routes to Claude or Gemini based on RESPONSE_MODEL) ---
+# --- Unified response text API (routes to Claude or Gemini based on model) ---
 
 
 async def response_text(prompt=None, **kwargs):
-    """Generate text using the configured RESPONSE_MODEL.
+    """Generate text using the specified or configured model.
 
-    Auto-routes to Claude or Gemini based on model name. Same interface as
-    gemini_text() / claude_text(). Use this instead of calling either directly
-    for any code that should respect the RESPONSE_MODEL setting.
+    Accepts a 'model' kwarg to override the default RESPONSE_MODEL, enabling
+    per-request model selection (e.g., user chooses model from the app).
+    Auto-routes to Claude or Gemini based on model name prefix.
     """
-    if _is_claude_model(RESPONSE_MODEL):
-        _log.info(f"response_text using Claude: {RESPONSE_MODEL}")
+    model = kwargs.get("model", RESPONSE_MODEL)
+    if _is_claude_model(model):
+        _log.info(f"response_text using Claude: {model}")
         return await claude_text(prompt, **kwargs)
     else:
-        _log.info(f"response_text using Gemini: {RESPONSE_MODEL}")
+        _log.info(f"response_text using Gemini: {model}")
         return await gemini_text(prompt, **kwargs)
 
 
@@ -380,6 +383,7 @@ async def gemini_text(prompt=None, **kwargs):
     from google.genai import types
 
     start_time = time.time()
+    model = kwargs.get("model", GEMINI_RESPONSE_MODEL)
     temperature = kwargs.get("temperature", 0.45)
 
     max_output_tokens = kwargs.get("max_output_tokens", 2048)
@@ -404,7 +408,7 @@ async def gemini_text(prompt=None, **kwargs):
     for attempt in range(GEMINI_MAX_RETRIES):
         try:
             response = await client.aio.models.generate_content(
-                model=GEMINI_RESPONSE_MODEL,
+                model=model,
                 contents=contents,
                 config=config,
             )

--- a/btcopilot/personal/chat.py
+++ b/btcopilot/personal/chat.py
@@ -17,12 +17,12 @@ class Response:
     statement: str
 
 
-def ask(discussion: Discussion, user_statement: str) -> Response:
+def ask(discussion: Discussion, user_statement: str, model: str | None = None) -> Response:
 
     ai_log.info(f"User statement: {user_statement}")
 
     # Build structured conversation turns before adding new statement to session
-    system_instruction = get_conversation_flow_prompt()
+    system_instruction = get_conversation_flow_prompt(model)
     if hasattr(g, "custom_prompts"):
         system_instruction = g.custom_prompts.get(
             "CONVERSATION_FLOW_PROMPT", system_instruction
@@ -42,7 +42,7 @@ def ask(discussion: Discussion, user_statement: str) -> Response:
     )
     db.session.add(statement)
 
-    ai_response = _generate_response(system_instruction, turns)
+    ai_response = _generate_response(system_instruction, turns, model=model)
     ai_log.info(f"AI response: {ai_response}")
 
     ai_statement = Statement(
@@ -55,10 +55,17 @@ def ask(discussion: Discussion, user_statement: str) -> Response:
     return Response(statement=ai_response)
 
 
-def _generate_response(system_instruction: str, turns: list[tuple[str, str]]) -> str:
-    ai_response = response_text_sync(
-        system_instruction=system_instruction,
-        turns=turns,
-        temperature=0.45,
-    )
+def _generate_response(
+    system_instruction: str,
+    turns: list[tuple[str, str]],
+    model: str | None = None,
+) -> str:
+    kwargs = {
+        "system_instruction": system_instruction,
+        "turns": turns,
+        "temperature": 0.45,
+    }
+    if model:
+        kwargs["model"] = model
+    ai_response = response_text_sync(**kwargs)
     return ai_response.strip()

--- a/btcopilot/personal/chat.py
+++ b/btcopilot/personal/chat.py
@@ -6,7 +6,7 @@ from flask import g
 from btcopilot.extensions import db, ai_log
 from btcopilot.llmutil import response_text_sync
 from btcopilot.personal.models import Discussion, Statement
-from btcopilot.personal.prompts import CONVERSATION_FLOW_PROMPT
+from btcopilot.personal.prompts import get_conversation_flow_prompt
 
 
 _log = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ def ask(discussion: Discussion, user_statement: str) -> Response:
     ai_log.info(f"User statement: {user_statement}")
 
     # Build structured conversation turns before adding new statement to session
-    system_instruction = CONVERSATION_FLOW_PROMPT
+    system_instruction = get_conversation_flow_prompt()
     if hasattr(g, "custom_prompts"):
         system_instruction = g.custom_prompts.get(
             "CONVERSATION_FLOW_PROMPT", system_instruction

--- a/btcopilot/personal/prompts.py
+++ b/btcopilot/personal/prompts.py
@@ -992,6 +992,22 @@ if _prompts_path:
             DATA_EXTRACTION_PASS2_CONTEXT = _private.DATA_EXTRACTION_PASS2_CONTEXT
             SARF_REVIEW_PROMPT = _private.SARF_REVIEW_PROMPT
 
+            # Per-model conversation prompt overrides (Option B).
+            # If the private file defines model-specific pieces, use them
+            # in get_conversation_flow_prompt() instead of the defaults.
+            if hasattr(_private, "_CONVERSATION_FLOW_CORE"):
+                _CONVERSATION_FLOW_CORE = _private._CONVERSATION_FLOW_CORE
+            if hasattr(_private, "_CONVERSATION_FLOW_OPUS"):
+                _CONVERSATION_FLOW_OPUS = _private._CONVERSATION_FLOW_OPUS
+            if hasattr(_private, "_CONVERSATION_FLOW_GEMINI"):
+                _CONVERSATION_FLOW_GEMINI = _private._CONVERSATION_FLOW_GEMINI
+
+            # Rebuild the default so the override-detection in
+            # get_conversation_flow_prompt() stays accurate.
+            _CONVERSATION_FLOW_DEFAULT = (
+                _CONVERSATION_FLOW_CORE + "\n" + _CONVERSATION_FLOW_GEMINI
+            )
+
             _log.info(f"Loaded private prompts from {_prompts_path}")
 
         except Exception as _e:

--- a/btcopilot/personal/prompts.py
+++ b/btcopilot/personal/prompts.py
@@ -7,10 +7,15 @@ Use the appropriate tense as if you were telling the user what they had said.
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# CONVERSATION FLOW PROMPT (Single induction target - fully editable)
+# CONVERSATION FLOW PROMPT — Split into core + model-specific addenda
+#
+# Core: Domain knowledge, conversation phases, data checklist, red flags
+# Addenda: Response style/texture tuned per model's natural tendencies
+#
+# Assembly: get_conversation_flow_prompt() combines core + active addendum
 # ═══════════════════════════════════════════════════════════════════════════════
 
-CONVERSATION_FLOW_PROMPT = """
+_CONVERSATION_FLOW_CORE = """
 
 **Role & Goal**
 
@@ -25,9 +30,6 @@ CONVERSATION_FLOW_PROMPT = """
   initially see.
 - Be warm and curious. Ask questions that invite stories: "How did your
   parents meet?" "What was going on in the family when you were born?"
-- Keep responses brief. One question per turn - like real conversation. Not
-  every turn needs a question; sometimes a short reflection or observation
-  keeps them talking without being asked.
 
 **Domain Knowledge Constraint**
 
@@ -246,8 +248,89 @@ back to WHO, WHEN, and how things shifted.
 - If pivoting from problem to family: "OK, I have a good picture of
   what's going on. Now let me get some family background. What's your
   mom's name and how old is she?"
-- Do NOT parrot back what the user just said - move the conversation forward
 """
+
+
+# ---------------------------------------------------------------------------
+# Model-specific addenda — appended to core based on active RESPONSE_MODEL
+# ---------------------------------------------------------------------------
+
+_CONVERSATION_FLOW_GEMINI = """
+**Response Style**:
+- Keep responses brief. One question per turn - like real conversation. Not
+  every turn needs a question; sometimes a short reflection or observation
+  keeps them talking without being asked.
+- Do NOT parrot back what the user just said - move the conversation forward.
+"""
+
+_CONVERSATION_FLOW_OPUS = """
+**Response Style**:
+
+Your responses should feel like a real conversation with someone who's done
+this hundreds of times — not a questionnaire. You use contractions. You
+speak like a real person. You're warm but direct.
+
+Vary your response types across turns. Not every turn should be a bare question:
+
+- **Question turns**: Ask one specific question, but frame it with natural
+  context: "I'm curious about your dad's side — what was his mother like?"
+  not just "What was your paternal grandmother's name?"
+- **Observation turns**: Reflect back a pattern or connection you notice:
+  "That's interesting — your mom moved cross-country the same year your
+  grandfather got sick. Those things often go together." Then let them respond
+  without piling on a question.
+- **Bridging turns**: When shifting topics, briefly acknowledge what they
+  shared before moving on: "That gives me a good picture of how things were
+  between your parents. Let me ask about your siblings."
+- **Normalizing turns**: After something heavy, a brief grounding comment
+  before continuing: "A lot of families go through that kind of shift after
+  a death. How did your brother handle it?"
+
+Aim for 2-4 sentences per response. One sentence feels abrupt. Five or more
+is lecturing. The sweet spot is enough to show you're tracking with them
+without dominating the conversation.
+
+Share a brief thought before your question when it's natural. The user should
+feel like they're talking WITH someone, not being interviewed by a checklist.
+
+When the user shares something significant, don't immediately pivot to the
+next data point. Spend one beat on what they said — not with therapy-speak,
+but with genuine engagement: "That's a big deal" or "That changes things" —
+then follow up.
+
+Do NOT parrot back what the user just said — move the conversation forward.
+Do NOT start your responses with "Thank you for sharing" or similar filler.
+"""
+
+
+# Backward-compatible alias — the default assembled prompt.
+# The private-prompts override mechanism may replace this at module load time.
+_CONVERSATION_FLOW_DEFAULT = _CONVERSATION_FLOW_CORE + "\n" + _CONVERSATION_FLOW_GEMINI
+CONVERSATION_FLOW_PROMPT = _CONVERSATION_FLOW_DEFAULT
+
+
+def get_conversation_flow_prompt(model: str | None = None) -> str:
+    """Assemble the conversation flow prompt for the given model.
+
+    Combines the shared core prompt with a model-specific style addendum.
+    Falls back to the Gemini addendum for unknown models.
+
+    If CONVERSATION_FLOW_PROMPT was overridden by private prompts (via
+    FDSERVER_PROMPTS_PATH), the override is used as-is regardless of model.
+    """
+    # If private prompts override replaced CONVERSATION_FLOW_PROMPT, use it
+    # directly — the production override is authoritative.
+    if CONVERSATION_FLOW_PROMPT != _CONVERSATION_FLOW_DEFAULT:
+        return CONVERSATION_FLOW_PROMPT
+
+    from btcopilot.llmutil import RESPONSE_MODEL, _is_claude_model
+
+    model = model or RESPONSE_MODEL
+    if _is_claude_model(model):
+        addendum = _CONVERSATION_FLOW_OPUS
+    else:
+        addendum = _CONVERSATION_FLOW_GEMINI
+    return _CONVERSATION_FLOW_CORE + "\n" + addendum
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/btcopilot/personal/routes/discussions.py
+++ b/btcopilot/personal/routes/discussions.py
@@ -115,7 +115,8 @@ def chat(discussion_id: int):
             user_speaker.person_id = user_person_id
 
     statement = request.json["statement"]
-    response: Response = ask(discussion, statement)
+    model = request.json.get("model")  # Optional per-request model override
+    response: Response = ask(discussion, statement, model=model)
 
     # Notify audit system of new statements (both user and AI)
     # from btcopilot.training.sse import sse_manager

--- a/plans/opus-conversational-prompts.md
+++ b/plans/opus-conversational-prompts.md
@@ -1,0 +1,227 @@
+# Opus-Specific Conversational Prompt Tuning
+
+## Problem Statement
+
+After switching from Gemini 3 Flash Preview to Claude Opus 4.6 for conversational responses, the output has degraded to terse, single-line questions. Gemini naturally produced more varied, conversational output with some warmth and flow. The current `CONVERSATION_FLOW_PROMPT` was tuned for Gemini and doesn't leverage Opus's strengths or account for its behavioral tendencies.
+
+**Goal**: Create a model-specific prompt layer so each model gets tuning that plays to its strengths, while sharing the core domain instructions.
+
+---
+
+## Analysis: Why Opus Produces Terse Output
+
+The current prompt heavily emphasizes brevity and constraint:
+- "Keep responses brief" (line 28)
+- "One question per turn" (line 28)
+- "Do NOT parrot back what the user just said" (line 249)
+- Long list of "AVOID" patterns (therapy clichés)
+- "RED FLAG" warnings about giving advice
+
+Gemini Flash naturally adds conversational texture despite these constraints — it tends toward verbosity, so the constraints act as useful guardrails. **Opus is the opposite**: it's already concise and instruction-following by nature. Telling an already-terse model to "keep responses brief" produces one-liners.
+
+Additionally, extended thinking is enabled (4096 token budget), which forces `temperature=1.0` per the Anthropic API — but the actual output is still constrained by the prompt's tone. The thinking budget may be "eating" creative energy that would otherwise go into the response.
+
+---
+
+## Architecture: Model-Specific Prompt System
+
+### Design
+
+Split the conversational prompt into:
+1. **Core prompt** (shared): Domain knowledge, conversation phases, data checklist, red flags — the "what to do"
+2. **Model-specific addendum** (per-model): Tone, style, response texture — the "how to do it"
+
+```
+CONVERSATION_FLOW_PROMPT_CORE = "..." # Shared domain instructions
+CONVERSATION_FLOW_PROMPT_OPUS = "..." # Opus-specific style guide
+CONVERSATION_FLOW_PROMPT_GEMINI = "..." # Gemini-specific style guide (current behavior preserved)
+```
+
+At runtime in `chat.py`, assemble the final prompt based on the active `RESPONSE_MODEL`:
+
+```python
+def _get_conversation_prompt():
+    if _is_claude_model(RESPONSE_MODEL):
+        return CONVERSATION_FLOW_PROMPT_CORE + "\n\n" + CONVERSATION_FLOW_PROMPT_OPUS
+    else:
+        return CONVERSATION_FLOW_PROMPT_CORE + "\n\n" + CONVERSATION_FLOW_PROMPT_GEMINI
+```
+
+The private prompts override mechanism stays intact — production can override the assembled prompt entirely via `g.custom_prompts`.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `btcopilot/personal/prompts.py` | Split `CONVERSATION_FLOW_PROMPT` into core + model addenda |
+| `btcopilot/personal/chat.py` | Import model-aware prompt assembly, use it in `ask()` |
+| `btcopilot/llmutil.py` | Export `_is_claude_model` and `RESPONSE_MODEL` (already available) |
+
+---
+
+## Opus-Specific Prompt Addendum: Design
+
+### Key Differences from Gemini Tuning
+
+| Aspect | Gemini Behavior (natural) | Opus Behavior (natural) | Opus Addendum Goal |
+|--------|---------------------------|------------------------|---------------------|
+| Length | Tends verbose, needs constraints | Tends terse, needs encouragement | Explicitly encourage 2-4 sentence responses |
+| Warmth | Naturally warm/chatty | Clinical precision | Add warmth cues without triggering therapy-speak |
+| Variety | Naturally varied | Tends to repeat patterns | Encourage response type rotation |
+| Questions | Asks fine, sometimes too many | Asks well but nothing else | Encourage observations, reflections, normalizing |
+| Thinking | N/A | Extended thinking enabled | May need thinking budget adjustment |
+
+### Opus Addendum Content (Draft)
+
+```
+**Response Style (Opus-specific)**
+
+Your responses should feel like a real conversation with a knowledgeable consultant —
+not a questionnaire. Vary your response types across turns:
+
+- **Question turns**: Ask one specific question. But frame it naturally: "I'm curious
+  about your dad's side — what was his mother like?" not just "What was your paternal
+  grandmother's name?"
+- **Observation turns**: Sometimes reflect back a pattern or connection you notice:
+  "That's interesting — your mom moved cross-country the same year your grandfather
+  got sick. Those things often go together." Then let them respond.
+- **Bridging turns**: When transitioning topics, acknowledge what they just shared
+  before asking about something new: "That gives me a good picture of how things
+  were between your parents. Let me ask about your siblings now."
+- **Normalizing turns**: When someone shares something heavy, a brief normalizing
+  comment before moving on: "A lot of families go through that kind of shift after
+  a death. How did your brother handle it?"
+
+Aim for 2-4 sentences per response. One sentence is too abrupt. Five+ is lecturing.
+The sweet spot is enough to show you're engaged without dominating the conversation.
+
+Don't be afraid to share a brief thought before asking your question. The user should
+feel like they're talking WITH someone, not being interviewed.
+
+When the user shares something emotional or significant, resist the urge to immediately
+pivot to the next data point. Spend one beat acknowledging what they said — not with
+therapy-speak, but with genuine human engagement: "That's a big deal" or "That must
+have changed everything" — then ask your follow-up.
+```
+
+### Gemini Addendum Content (Preserve Current Behavior)
+
+```
+**Response Style (Gemini-specific)**
+
+Keep responses brief. One question per turn — like real conversation. Not every turn
+needs a question; sometimes a short reflection or observation keeps them talking
+without being asked.
+
+Do NOT parrot back what the user just said — move the conversation forward.
+```
+
+This preserves the existing Gemini behavior exactly as-is.
+
+---
+
+## Experiments to Run
+
+### Experiment 1: Baseline Comparison (Before Any Changes)
+
+**Goal**: Document current Opus output quality to measure improvement.
+
+**Method**:
+1. Run 3 synthetic conversations with current prompts using Opus
+2. Run 3 synthetic conversations with current prompts using Gemini
+3. Score both using `ClientRealismEvaluator` (adapted for coach-side evaluation)
+4. Document: average response length, question-only ratio, response type variety
+
+**Metrics**:
+- Average words per AI response
+- % of responses that are single questions only (no other content)
+- Response type distribution (question / observation / bridge / normalization)
+- Subjective warmth rating (1-5, human-judged from sample)
+
+### Experiment 2: Opus Addendum A — Gentle Encouragement
+
+**Goal**: Test whether light-touch style guidance improves variety without losing focus.
+
+**Addendum**: The draft above — encourage 2-4 sentences, vary response types, brief acknowledgments before questions.
+
+**Hypothesis**: Response length increases to 2-3 sentences average, question-only ratio drops below 50%, warmth improves.
+
+### Experiment 3: Opus Addendum B — Stronger Persona
+
+**Goal**: Test whether giving Opus a stronger consultant persona improves naturalness.
+
+**Addendum variant**:
+```
+You are an experienced family systems consultant who has done hundreds of these
+intake conversations. You're genuinely fascinated by family patterns — not in an
+academic way, but because you've seen how powerful it is when people start to see
+the connections in their own family's story. You speak like a real person having
+a real conversation. You use contractions. You occasionally share brief observations.
+You're warm but direct — you don't pad your responses with filler, but you also
+don't fire questions like you're reading from a checklist.
+```
+
+**Hypothesis**: Persona framing gives Opus more creative latitude while staying in-role.
+
+### Experiment 4: Thinking Budget Tuning
+
+**Goal**: Test whether extended thinking budget affects response quality/variety.
+
+**Variants**:
+- A: `CLAUDE_THINKING_BUDGET = 0` (disable thinking entirely)
+- B: `CLAUDE_THINKING_BUDGET = 2048` (current: 4096)
+- C: `CLAUDE_THINKING_BUDGET = 8192` (more thinking)
+
+**Hypothesis**: Thinking may be over-constraining responses. With 4096 tokens of "careful thought," Opus may be over-analyzing and producing ultra-safe, minimal responses. Reducing the budget might produce more natural flow.
+
+**Note**: Disabling thinking also means temperature is no longer forced to 1.0 — the configured 0.45 would take effect, which could independently affect output quality.
+
+### Experiment 5: Temperature Exploration (Thinking Disabled)
+
+**Goal**: If thinking is disabled, explore temperature's effect on conversational quality.
+
+**Variants**: 0.45, 0.6, 0.75, 0.9
+
+**Hypothesis**: Higher temperature with Opus (no thinking) may produce more varied, natural responses. The current 0.45 was tuned for Gemini.
+
+### Experiment 6: Combined Best Settings
+
+**Goal**: Combine the winning addendum with the best thinking/temperature settings.
+
+**Method**: Take best from experiments 2-5, run full synthetic conversation suite, compare against Experiment 1 baselines for both Opus and Gemini.
+
+---
+
+## Implementation Sequence
+
+### Phase 1: Architecture (prompt splitting)
+1. Split `CONVERSATION_FLOW_PROMPT` into `_CORE` + model addenda in `prompts.py`
+2. Add model-aware prompt assembly function
+3. Update `chat.py` to use the assembled prompt
+4. Update private prompts override to handle new structure (backward compatible)
+5. Verify Gemini behavior unchanged (addendum preserves current text exactly)
+
+### Phase 2: Baseline measurement
+6. Run Experiment 1 — document current Opus and Gemini baselines
+
+### Phase 3: Prompt tuning
+7. Run Experiments 2 and 3 — test addendum variants
+8. Pick best addendum, iterate if needed
+
+### Phase 4: Technical tuning
+9. Run Experiments 4 and 5 — thinking budget + temperature
+10. Run Experiment 6 — combined best settings
+
+### Phase 5: Integration
+11. Commit final prompt + settings
+12. Update `doc/PROMPT_ENGINEERING_LOG.md` with findings
+13. Update `doc/CHAT_FLOW.md` with model-specific prompt architecture
+
+---
+
+## Risk Assessment
+
+- **Low risk**: Prompt changes only affect conversational output, not extraction (separate model/prompts)
+- **Reversible**: Environment variable `BTCOPILOT_RESPONSE_MODEL` allows instant model switching
+- **No data impact**: Chat responses aren't used for training data or F1 metrics
+- **Backward compatible**: Private prompts override still works; Gemini behavior preserved exactly


### PR DESCRIPTION
Split CONVERSATION_FLOW_PROMPT into shared core (domain knowledge, phases,
checklist) and model-specific style addenda. Opus gets richer conversational
texture guidance (2-4 sentences, observation/bridging/normalizing turns,
natural framing) to counteract its tendency toward terse single-line
questions. Gemini addendum preserves existing brevity constraints.

chat.py now calls get_conversation_flow_prompt() which assembles the right
prompt based on RESPONSE_MODEL. Private prompts override (FDSERVER_PROMPTS_PATH)
remains fully backward compatible — overrides take precedence over assembly.

https://claude.ai/code/session_01DN262ZGcrEWCryiVmQphkD