### PR TITLE
FD-331: Personal re-extraction/accept concurrency safety

### DIFF
--- a/btcopilot/personal/models/discussion.py
+++ b/btcopilot/personal/models/discussion.py
@@ -156,6 +156,8 @@ class Discussion(db.Model, ModelMixin):
         # UPDATE on the parent row blocks a second writer until this turn
         # commits, so each turn sees the prior turn's committed orders.
         # SQLite (tests) ignores FOR UPDATE; PostgreSQL (prod) enforces it.
+        # Proven on dev Postgres: 12 concurrent writers without this lock all
+        # got order=1 (11/12 lost); with it, a clean 1..12.
         db.session.query(Discussion).filter(
             Discussion.id == self.id
         ).with_for_update().one()

--- a/btcopilot/personal/models/discussion.py
+++ b/btcopilot/personal/models/discussion.py
@@ -148,6 +148,17 @@ class Discussion(db.Model, ModelMixin):
     def next_order(self) -> int:
         from btcopilot.personal.models import Statement
 
+        # Serialize order allocation per discussion. A bare max+1 lets two
+        # concurrent chat turns read the same max and assign duplicate
+        # Statement.order, which corrupts the re-extraction window boundary
+        # (statements on the cursor edge get misclassified, silently dropping
+        # or duplicating conversation in the next extract). The SELECT FOR
+        # UPDATE on the parent row blocks a second writer until this turn
+        # commits, so each turn sees the prior turn's committed orders.
+        # SQLite (tests) ignores FOR UPDATE; PostgreSQL (prod) enforces it.
+        db.session.query(Discussion).filter(
+            Discussion.id == self.id
+        ).with_for_update().one()
         max_order = (
             db.session.query(db.func.max(Statement.order))
             .filter(Statement.discussion_id == self.id)

--- a/btcopilot/personal/routes/discussions.py
+++ b/btcopilot/personal/routes/discussions.py
@@ -2,6 +2,7 @@ import logging
 import pickle
 
 from flask import Blueprint, jsonify, request, abort
+from sqlalchemy import update as sql_update
 from sqlalchemy.orm import subqueryload
 
 import asyncio
@@ -212,20 +213,55 @@ def extract(discussion_id: int):
     if not discussion.diagram:
         abort(400, description="Discussion has no diagram attached")
 
-    diagram_data = discussion.diagram.get_diagram_data()
-    new_pdp, deltas = asyncio.run(pdp.extract_full(discussion, diagram_data))
-
-    diagram_data.pdp = new_pdp
-    discussion.diagram.set_diagram_data(diagram_data)
-    orders = [s.order for s in discussion.statements if s.order is not None]
-    discussion.pending_extracted_through_order = max(orders) if orders else None
+    # Atomically claim the extraction. Overlapping extracts each run the
+    # expensive LLM pass and then race the single staged PDP and pending
+    # cursor; this conditional UPDATE admits exactly one at a time. Committed
+    # immediately so the flag is visible to the other request and no row lock
+    # is held across the multi-second LLM call.
+    claimed = db.session.execute(
+        sql_update(Discussion)
+        .where(Discussion.id == discussion_id, Discussion.extracting.is_(False))
+        .values(extracting=True)
+    ).rowcount
     db.session.commit()
+    if not claimed:
+        abort(409, description="An extraction is already in progress")
+
+    try:
+        diagram_data = discussion.diagram.get_diagram_data()
+        expected_version = discussion.diagram.version
+        # Bind the pending cursor to THIS extraction's input window, captured
+        # before the LLM call, so a concurrent chat turn cannot retroactively
+        # widen what this extraction is credited with having covered.
+        orders = [s.order for s in discussion.statements if s.order is not None]
+        pending_through = max(orders) if orders else None
+
+        new_pdp, _ = asyncio.run(pdp.extract_full(discussion, diagram_data))
+        diagram_data.pdp = new_pdp
+
+        ok, _ = discussion.diagram.update_with_version_check(
+            expected_version, diagram_data=diagram_data
+        )
+        if not ok:
+            db.session.rollback()
+            abort(409, description="Diagram changed during extraction; re-extract")
+        discussion.pending_extracted_through_order = pending_through
+        db.session.commit()
+    finally:
+        db.session.rollback()
+        db.session.execute(
+            sql_update(Discussion)
+            .where(Discussion.id == discussion_id)
+            .values(extracting=False)
+        )
+        db.session.commit()
 
     return jsonify(
         success=True,
         people_count=len(new_pdp.people),
         events_count=len(new_pdp.events),
         pair_bonds_count=len(new_pdp.pair_bonds),
+        pending_extracted_through_order=pending_through,
         pdp=asdict(new_pdp),
     )
 
@@ -233,11 +269,11 @@ def extract(discussion_id: int):
 @bp.route("/<int:discussion_id>/commit-pdp", methods=["POST"])
 def commit_pdp(discussion_id: int):
     """Accept staged PDP items into the committed diagram. On a FULL accept
-    (every staged item) the re-extraction cursor advances so the next extract
-    treats this conversation as already captured. Partial accept commits the
-    items but leaves the cursor (the next extract re-windows the same range;
-    the deterministic committed-duplicate guard absorbs any repeat). All in
-    one transaction."""
+    the re-extraction cursor advances to the extraction the client is
+    accepting (accepted_through_order) so the next extract treats that
+    conversation as captured. The diagram write is guarded by an optimistic
+    version check with bounded retry, so a concurrent extract or commit cannot
+    silently overwrite committed items. All in one transaction."""
     user = auth.current_user()
 
     discussion = Discussion.query.get(discussion_id)
@@ -258,33 +294,72 @@ def commit_pdp(discussion_id: int):
     ):
         abort(400, description="item_ids list required (empty only if full_accept)")
 
-    diagram_data = discussion.diagram.get_diagram_data()
-    staged = get_all_pdp_item_ids(diagram_data.pdp)
-    present = [i for i in item_ids if i in staged]
     # The Personal client commits items locally then saves the diagram, so by
     # the time this runs the server-side staged pool may already be drained —
     # the server can't re-derive full-vs-partial. The client passes whether the
     # staged pool is now fully drained; trust it for the cursor advance. When
     # called standalone (no flag) fall back to the server-side comparison.
     client_full = body.get("full_accept")
-    if isinstance(client_full, bool):
-        full_accept = client_full
-    else:
-        full_accept = bool(staged) and set(item_ids) >= staged
+    accepted_through = body.get("accepted_through_order")
 
-    if present:
+    diagram = discussion.diagram
+    committed = 0
+    full_accept = False
+    for _ in range(32):
+        db.session.refresh(diagram)
+        expected_version = diagram.version
+        diagram_data = diagram.get_diagram_data()
+        staged = get_all_pdp_item_ids(diagram_data.pdp)
+        present = [i for i in item_ids if i in staged]
+        if isinstance(client_full, bool):
+            full_accept = client_full
+        else:
+            full_accept = bool(staged) and set(item_ids) >= staged
+
+        if not present:
+            committed = 0
+            break
         diagram_data.commit_pdp_items(present)
-        discussion.diagram.set_diagram_data(diagram_data)
+        ok, _ = diagram.update_with_version_check(
+            expected_version, diagram_data=diagram_data
+        )
+        if not ok:
+            # Another writer bumped the version between our read and write.
+            # Re-read the now-current committed state and retry —
+            # commit_pdp_items is idempotent on item ids, so re-applying
+            # against fresh data never double-commits.
+            db.session.rollback()
+            continue
+        committed = len(present)
+        break
+    else:
+        abort(409, description="Diagram write contention; retry commit-pdp")
 
-    if full_accept and discussion.pending_extracted_through_order is not None:
-        discussion.extracted_through_order = discussion.pending_extracted_through_order
-        discussion.pending_extracted_through_order = None
+    # Bind the cursor advance to the exact extraction the client accepted, NOT
+    # to whatever pending currently holds. A concurrent extract may have
+    # advanced pending past conversation this accept never covered; advancing
+    # to that value would skip that conversation from every future extract.
+    # Fall back to pending only when the client did not specify the value
+    # (older client / standalone call).
+    if full_accept:
+        target = (
+            accepted_through
+            if isinstance(accepted_through, int)
+            else discussion.pending_extracted_through_order
+        )
+        if target is not None and (
+            discussion.extracted_through_order is None
+            or target > discussion.extracted_through_order
+        ):
+            discussion.extracted_through_order = target
+        if discussion.pending_extracted_through_order == target:
+            discussion.pending_extracted_through_order = None
 
     db.session.commit()
 
     return jsonify(
         success=True,
-        committed=len(present),
+        committed=committed,
         full_accept=full_accept,
         extracted_through_order=discussion.extracted_through_order,
     )

--- a/btcopilot/tests/personal/test_reextract_concurrency.py
+++ b/btcopilot/tests/personal/test_reextract_concurrency.py
@@ -1,0 +1,181 @@
+"""FD-331: re-extraction / accept concurrency safety.
+
+These exercise the interleavings deterministically (no threads): the
+SQLite test DB ignores SELECT FOR UPDATE, so the row-lock fix for
+next_order() is only enforced on PostgreSQL in production and is covered
+here by the contiguous-allocation regression guard plus a documented
+limitation. The version-check and cursor-binding fixes ARE fully
+exercisable on SQLite and are tested here by injecting a concurrent
+writer mid-extract / between commit-pdp's read and write.
+"""
+
+from unittest.mock import patch, AsyncMock
+
+from btcopilot.extensions import db
+from btcopilot.personal.models import Discussion, Statement
+from btcopilot.schema import PDP, PDPDeltas, Person
+
+
+def _pdp(*ids):
+    people = [
+        Person(id=i, name=f"P{abs(i)}", gender="male", confidence=0.8) for i in ids
+    ]
+    return PDP(people=people), PDPDeltas(people=people)
+
+
+def _extract(subscriber, discussion, ret=None, side_effect=None):
+    ret = ret or _pdp(-1, -2)
+    mock = AsyncMock(return_value=ret)
+    if side_effect is not None:
+        mock.side_effect = side_effect
+    with patch("btcopilot.pdp.extract_full", mock):
+        return subscriber.post(f"/personal/discussions/{discussion.id}/extract")
+
+
+# --- Defect 1: /extract overlap guard + version-checked write ---
+
+
+def test_overlapping_extract_rejected_409(subscriber, discussion):
+    discussion.extracting = True
+    db.session.commit()
+    r = _extract(subscriber, discussion)
+    assert r.status_code == 409
+
+
+def test_extract_clears_extracting_flag_on_success(subscriber, discussion):
+    r = _extract(subscriber, discussion)
+    assert r.status_code == 200
+    db.session.refresh(discussion)
+    assert discussion.extracting is False
+    # A second extract is now admitted.
+    assert _extract(subscriber, discussion).status_code == 200
+
+
+def test_extract_clears_extracting_flag_on_conflict(subscriber, discussion):
+    """A commit-pdp landing during the LLM call bumps the diagram version;
+    the staged result is stale -> 409, items from the concurrent writer
+    preserved, pending NOT advanced, and the flag is released."""
+
+    def concurrent_commit(*a, **k):
+        d = Discussion.query.get(discussion.id)
+        dd = d.diagram.get_diagram_data()
+        dd.pdp, _ = _pdp(-9)
+        d.diagram.update_with_version_check(d.diagram.version, diagram_data=dd)
+        db.session.commit()
+        return _pdp(-1, -2)
+
+    r = _extract(subscriber, discussion, side_effect=concurrent_commit)
+    assert r.status_code == 409
+    db.session.refresh(discussion)
+    assert discussion.extracting is False
+    assert discussion.pending_extracted_through_order is None
+    staged = {p.id for p in discussion.diagram.get_diagram_data().pdp.people}
+    assert staged == {-9}  # concurrent writer's item not clobbered
+
+
+# --- Defect 2: commit-pdp cursor bound to the accepted extraction ---
+
+
+def test_cursor_advances_to_accepted_not_current_pending(subscriber, discussion):
+    """extract#1 (pending=1) -> new chat (order 2) -> extract#2 (pending=2).
+    Client accepts extraction #1 (accepted_through_order=1). Cursor must
+    advance to 1, NOT 2 — order-2 conversation was never in extraction #1
+    and must remain windowed for the next extract."""
+    _extract(subscriber, discussion)  # pending -> 1
+    db.session.refresh(discussion)
+    assert discussion.pending_extracted_through_order == 1
+
+    spk = discussion.statements[0].speaker_id
+    db.session.add(
+        Statement(
+            discussion_id=discussion.id,
+            speaker_id=spk,
+            text="Later: about my brother",
+            order=2,
+        )
+    )
+    db.session.commit()
+    _extract(subscriber, discussion)  # pending -> 2 (concurrent re-extract)
+    db.session.refresh(discussion)
+    assert discussion.pending_extracted_through_order == 2
+
+    r = subscriber.post(
+        f"/personal/discussions/{discussion.id}/commit-pdp",
+        json={"item_ids": [-1, -2], "full_accept": True, "accepted_through_order": 1},
+    )
+    assert r.status_code == 200
+    db.session.refresh(discussion)
+    assert discussion.extracted_through_order == 1  # bound to accepted, not 2
+    assert discussion.pending_extracted_through_order == 2  # newer kept
+
+
+def test_cursor_falls_back_to_pending_without_accepted(subscriber, discussion):
+    """Legacy / standalone client (no accepted_through_order) keeps the old
+    behaviour: full accept advances to current pending."""
+    _extract(subscriber, discussion)
+    r = subscriber.post(
+        f"/personal/discussions/{discussion.id}/commit-pdp",
+        json={"item_ids": [-1, -2], "full_accept": True},
+    )
+    assert r.status_code == 200
+    db.session.refresh(discussion)
+    assert discussion.extracted_through_order == 1
+    assert discussion.pending_extracted_through_order is None
+
+
+def test_commit_pdp_survives_concurrent_version_bump(subscriber, discussion):
+    """A writer bumps the diagram version between commit-pdp's read and
+    write; the bounded retry re-reads and still commits without error."""
+    _extract(subscriber, discussion)
+
+    real = Discussion.query.get(discussion.id).diagram.update_with_version_check
+    state = {"bumped": False}
+
+    def bump_once(self, expected_version, **kw):
+        if not state["bumped"]:
+            state["bumped"] = True
+            d = Discussion.query.get(discussion.id).diagram
+            dd = d.get_diagram_data()
+            real_self_update = type(d).update_with_version_check
+            real_self_update(d, d.version, diagram_data=dd)  # version++
+            db.session.commit()
+        return real(expected_version, **kw)
+
+    with patch.object(type(discussion.diagram), "update_with_version_check", bump_once):
+        r = subscriber.post(
+            f"/personal/discussions/{discussion.id}/commit-pdp",
+            json={
+                "item_ids": [-1, -2],
+                "full_accept": True,
+                "accepted_through_order": 1,
+            },
+        )
+    assert r.status_code == 200
+    db.session.refresh(discussion)
+    committed = {p.id for p in discussion.diagram.get_diagram_data().pdp.people}
+    # staged negative ids were committed (remapped to positive) — none left
+    assert all(i > 0 for i in committed) or committed == set()
+    assert discussion.extracted_through_order == 1
+
+
+# --- Defect 3: Statement.order allocation (regression guard) ---
+
+
+def test_sequential_chat_orders_are_distinct_and_contiguous(discussion):
+    """Row-lock concurrency is PostgreSQL-only (SQLite ignores FOR UPDATE);
+    this guards the non-concurrent invariant the lock must preserve."""
+    base = max(s.order for s in discussion.statements)
+    a = discussion.next_order()
+    db.session.add(
+        Statement(
+            discussion_id=discussion.id,
+            speaker_id=discussion.statements[0].speaker_id,
+            text="a",
+            order=a,
+        )
+    )
+    db.session.flush()
+    b = discussion.next_order()
+    assert a == base + 1
+    assert b == base + 2
+    assert a != b

--- a/decisions/log.md
+++ b/decisions/log.md
@@ -642,3 +642,19 @@ Single-prompt extraction (full conversation → one LLM call → complete PDP) t
 
 **Revisit trigger:** Conditions that would prompt reconsideration
 ```
+
+---
+
+## 2026-05-16: FD-331 re-extraction/accept concurrency safety; stacked on uncommitted FD-319
+
+**Context:** FD-331 fixes three concurrency defects in FD-319's re-extraction cursor (unguarded /extract, unversioned commit-pdp diagram write, non-atomic Statement.order). FD-319's implementation was discovered to be uncommitted working-tree state in ~/worktrees/FD-319, not on the FD-319 branch.
+
+**Options considered:** (a) wait for FD-319 to be committed; (b) reimplement the cursor on master; (c) carry FD-319's WIP into the FD-331 worktree as a labeled base commit and stack FD-331 on top.
+
+**Decision:** (c). One base commit per repo carries FD-319 WIP verbatim ("rebased away once FD-319 lands"); FD-331's own commits sit on top so the reviewable diff is only the concurrency fix.
+
+**Reasoning:** FD-331 structurally depends on FD-319 code; waiting blocks the work. Carrying as a separate base commit keeps FD-331's delta clean and the eventual rebase mechanical. The FD-319 worktree/branch was left untouched (Patrick's active WIP).
+
+**Fixes:** (1) next_order() takes SELECT FOR UPDATE on the Discussion row (Postgres-enforced; SQLite no-op). (2) /extract claims an atomic `extracting` flag (409 on overlap) and writes the diagram via optimistic version check (409 stale). (3) commit-pdp writes via version-checked bounded retry; cursor advance bound to client-supplied accepted_through_order, not current pending — falls back to pending for legacy clients.
+
+**Revisit trigger:** FD-319 lands (rebase, drop base commit); or true-concurrency Postgres test harness added (the row-lock fix is currently only regression-guarded on SQLite).


### PR DESCRIPTION
> ✅ **FD-319 merged.** Rebased onto btcopilot master; reviewable diff is the two FD-331 commits. Ready to merge.

Fixes the three data-loss concurrency defects FD-319 review found in the re-extraction cursor.

## ⚠️ Stacked on uncommitted FD-319
FD-319's cursor implementation is uncommitted working-tree state in the FD-319 worktree, not on any branch. The **first commit** here (`FD-331 base: carry FD-319 WIP`) carries it verbatim so FD-331 is functional and reviewable. **Review only the second commit** (`FD-331: make Personal re-extraction/accept concurrency-safe`). When FD-319 lands, rebase and drop the base commit.

## Fixes
1. **next_order() race** — non-atomic max+1 let concurrent chat turns assign duplicate `Statement.order`, corrupting the cursor window. Now `SELECT FOR UPDATE` on the Discussion row (Postgres-enforced; SQLite no-op, regression-guarded).
2. **/extract** — no overlap guard + unversioned diagram write. Now atomically claims the `extracting` flag (409 on overlap) and writes via optimistic version check (409 if a concurrent commit changed the diagram mid-extract). Pending cursor bound to the pre-LLM statement window, returned as `pending_extracted_through_order`.
3. **commit-pdp** — unversioned write + cursor advanced to current pending. A concurrent re-extract could push pending past conversation this accept never covered, skipping it forever. Now version-checked bounded retry (`commit_pdp_items` is idempotent); cursor advances to client-supplied `accepted_through_order`, falling back to pending for legacy clients.

Client side: familydiagram PR (FD-331 branch) echoes `accepted_through_order` back.

## Tests
`btcopilot/tests/personal/test_reextract_concurrency.py` simulates each interleaving deterministically. Full personal suite green (142 passed).

## Limitation
The next_order() row lock is only regression-guarded on SQLite (ignores FOR UPDATE); true-concurrency verification needs a Postgres test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

