### PR TITLE
FD-337: windowed re-extraction + cross-session parent back-fill

### DIFF
--- a/btcopilot/llmutil.py
+++ b/btcopilot/llmutil.py
@@ -351,7 +351,7 @@ def response_text_sync(prompt=None, model=None, **kwargs):
 # --- Public API ---
 
 
-async def gemini_structured(prompt, response_format, large=False):
+async def gemini_structured(prompt, response_format, large=False, model=None):
     from google.genai import types
 
     start_time = time.time()
@@ -359,7 +359,7 @@ async def gemini_structured(prompt, response_format, large=False):
         response_format, PDP_SCHEMA_DESCRIPTIONS, PDP_FORCE_REQUIRED
     )
 
-    model = EXTRACTION_MODEL_LARGE if large else EXTRACTION_MODEL
+    model = model or (EXTRACTION_MODEL_LARGE if large else EXTRACTION_MODEL)
 
     client = _client()
     config = types.GenerateContentConfig(

--- a/btcopilot/pdp.py
+++ b/btcopilot/pdp.py
@@ -1197,6 +1197,66 @@ def _windowed_conversation(discussion) -> tuple[str, str | None]:
     return prior + marker + tail, nonce
 
 
+WINDOW_SIZE = int(os.getenv("FD_WINDOW_SIZE", "80"))
+
+
+def _fmt_stmts(stmts) -> str:
+    return "\n".join(
+        f"{s.speaker.name if s.speaker else 'Unknown'}: {s.text}" for s in stmts
+    )
+
+
+def _restage_new_items(working: DiagramData, original: DiagramData) -> PDP:
+    """Re-stage items committed across windows that are absent from the original
+    diagram as a fresh negative-id PDP. References into original committed items
+    stay positive; references among the new items are remapped to negatives."""
+    orig_people = {p["id"] for p in original.people}
+    orig_events = {e["id"] for e in original.events}
+    orig_bonds = {pb["id"] for pb in original.pair_bonds}
+
+    new_people = [p for p in working.people if p["id"] not in orig_people]
+    new_events = [e for e in working.events if e["id"] not in orig_events]
+    new_bonds = [pb for pb in working.pair_bonds if pb["id"] not in orig_bonds]
+
+    next_id = -1
+    id_map: dict[int, int] = {}
+    for item in [*new_people, *new_bonds, *new_events]:
+        id_map[item["id"]] = next_id
+        next_id -= 1
+
+    def remap(old):
+        return id_map.get(old, old) if old is not None else None
+
+    people, bonds, events = [], [], []
+    for p in new_people:
+        d = dict(p)
+        d["id"] = id_map[p["id"]]
+        d["parents"] = remap(p.get("parents"))
+        people.append(from_dict(Person, d))
+    for pb in new_bonds:
+        d = dict(pb)
+        d["id"] = id_map[pb["id"]]
+        d["person_a"] = remap(pb.get("person_a"))
+        d["person_b"] = remap(pb.get("person_b"))
+        bonds.append(from_dict(PairBond, d))
+    for e in new_events:
+        d = dict(e)
+        d["id"] = id_map[e["id"]]
+        for k in ("person", "spouse", "child"):
+            d[k] = remap(d.get(k))
+        d["relationshipTargets"] = [remap(t) for t in d.get("relationshipTargets") or []]
+        d["relationshipTriangles"] = [
+            remap(t) for t in d.get("relationshipTriangles") or []
+        ]
+        for k in ("dateTime", "endDateTime"):
+            v = d.get(k)
+            if v is not None and hasattr(v, "toString"):
+                d[k] = v.toString("yyyy-MM-dd")
+        events.append(from_dict(Event, d))
+
+    return PDP(people=people, events=events, pair_bonds=bonds)
+
+
 async def extract_full(
     discussion,
     diagram_data: DiagramData,
@@ -1204,23 +1264,80 @@ async def extract_full(
     sarf_review_prompt: str | None = None,
     sarf_review_model: str | None = None,
 ) -> tuple[PDP, PDPDeltas]:
-    diagram_data.pdp = PDP()
     reference_date = (
         discussion.discussion_date
         if discussion.discussion_date
         else datetime.now().date()
     )
-    conversation, cursor_nonce = _windowed_conversation(discussion)
-    return await _two_pass_extract(
-        diagram_data,
-        conversation,
-        reference_date.isoformat(),
-        "extract_full",
-        pass2_prompt=pass2_prompt,
-        sarf_review_prompt=sarf_review_prompt,
-        sarf_review_model=sarf_review_model,
-        cursor_nonce=cursor_nonce,
+    ref = reference_date.isoformat()
+
+    ordered = sorted(discussion.statements, key=lambda s: (s.order or 0, s.id or 0))
+    cursor = discussion.extracted_through_order
+    if cursor is None:
+        to_extract = ordered
+        prior_committed = []
+    else:
+        to_extract = [s for s in ordered if (s.order or 0) > cursor]
+        prior_committed = [s for s in ordered if (s.order or 0) <= cursor]
+
+    if len(to_extract) <= WINDOW_SIZE:
+        diagram_data.pdp = PDP()
+        conversation, cursor_nonce = _windowed_conversation(discussion)
+        return await _two_pass_extract(
+            diagram_data,
+            conversation,
+            ref,
+            "extract_full",
+            pass2_prompt=pass2_prompt,
+            sarf_review_prompt=sarf_review_prompt,
+            sarf_review_model=sarf_review_model,
+            cursor_nonce=cursor_nonce,
+        )
+
+    working = DiagramData(
+        people=copy.deepcopy(diagram_data.people),
+        events=copy.deepcopy(diagram_data.events),
+        pair_bonds=copy.deepcopy(diagram_data.pair_bonds),
+        lastItemId=diagram_data.lastItemId,
     )
+
+    for start in range(0, len(to_extract), WINDOW_SIZE):
+        window = to_extract[start : start + WINDOW_SIZE]
+        prior = prior_committed + to_extract[:start]
+        if prior:
+            nonce = secrets.token_hex(8)
+            marker = CURSOR_MARKER_TEMPLATE.format(nonce=nonce)
+            conversation = _fmt_stmts(prior) + marker + _fmt_stmts(window)
+        else:
+            nonce = None
+            conversation = _fmt_stmts(window)
+
+        working.pdp = PDP()
+        pdp, _ = await _two_pass_extract(
+            working,
+            conversation,
+            ref,
+            "extract_full_window",
+            pass2_prompt=pass2_prompt,
+            sarf_review_prompt=sarf_review_prompt,
+            sarf_review_model=sarf_review_model,
+            cursor_nonce=nonce,
+        )
+        working.pdp = pdp
+        ids = [p.id for p in pdp.people if p.id is not None and p.id < 0]
+        ids += [e.id for e in pdp.events if e.id is not None and e.id < 0]
+        ids += [pb.id for pb in pdp.pair_bonds if pb.id is not None and pb.id < 0]
+        if ids:
+            working.commit_pdp_items(ids)
+
+    staged = _restage_new_items(working, diagram_data)
+    diagram_data.pdp = staged
+    deltas = PDPDeltas(
+        people=list(staged.people),
+        events=list(staged.events),
+        pair_bonds=list(staged.pair_bonds),
+    )
+    return staged, deltas
 
 
 async def import_text(

--- a/btcopilot/pdp.py
+++ b/btcopilot/pdp.py
@@ -1219,34 +1219,45 @@ def _restage_new_items(working: DiagramData, original: DiagramData) -> PDP:
     new_bonds = [pb for pb in working.pair_bonds if pb["id"] not in orig_bonds]
 
     next_id = -1
-    id_map: dict[int, int] = {}
-    for item in [*new_people, *new_bonds, *new_events]:
-        id_map[item["id"]] = next_id
+    person_map: dict[int, int] = {}
+    bond_map: dict[int, int] = {}
+    event_map: dict[int, int] = {}
+    for p in new_people:
+        person_map[p["id"]] = next_id
+        next_id -= 1
+    for pb in new_bonds:
+        bond_map[pb["id"]] = next_id
+        next_id -= 1
+    for e in new_events:
+        event_map[e["id"]] = next_id
         next_id -= 1
 
-    def remap(old):
-        return id_map.get(old, old) if old is not None else None
+    def rperson(old):
+        return person_map.get(old, old) if old is not None else None
+
+    def rbond(old):
+        return bond_map.get(old, old) if old is not None else None
 
     people, bonds, events = [], [], []
     for p in new_people:
         d = dict(p)
-        d["id"] = id_map[p["id"]]
-        d["parents"] = remap(p.get("parents"))
+        d["id"] = person_map[p["id"]]
+        d["parents"] = rbond(p.get("parents"))
         people.append(from_dict(Person, d))
     for pb in new_bonds:
         d = dict(pb)
-        d["id"] = id_map[pb["id"]]
-        d["person_a"] = remap(pb.get("person_a"))
-        d["person_b"] = remap(pb.get("person_b"))
+        d["id"] = bond_map[pb["id"]]
+        d["person_a"] = rperson(pb.get("person_a"))
+        d["person_b"] = rperson(pb.get("person_b"))
         bonds.append(from_dict(PairBond, d))
     for e in new_events:
         d = dict(e)
-        d["id"] = id_map[e["id"]]
+        d["id"] = event_map[e["id"]]
         for k in ("person", "spouse", "child"):
-            d[k] = remap(d.get(k))
-        d["relationshipTargets"] = [remap(t) for t in d.get("relationshipTargets") or []]
+            d[k] = rperson(d.get(k))
+        d["relationshipTargets"] = [rperson(t) for t in d.get("relationshipTargets") or []]
         d["relationshipTriangles"] = [
-            remap(t) for t in d.get("relationshipTriangles") or []
+            rperson(t) for t in d.get("relationshipTriangles") or []
         ]
         for k in ("dateTime", "endDateTime"):
             v = d.get(k)
@@ -1279,6 +1290,10 @@ async def extract_full(
     else:
         to_extract = [s for s in ordered if (s.order or 0) > cursor]
         prior_committed = [s for s in ordered if (s.order or 0) <= cursor]
+
+    if not to_extract:
+        diagram_data.pdp = PDP()
+        return PDP(), PDPDeltas()
 
     if len(to_extract) <= WINDOW_SIZE:
         diagram_data.pdp = PDP()

--- a/btcopilot/schema.py
+++ b/btcopilot/schema.py
@@ -680,6 +680,8 @@ class DiagramData:
                         event_dict[key] = validatedDateTimeText(value)
                 self.events.append(event_dict)
 
+        self._backfill_committed_parents()
+
         self.pdp.people = [p for p in self.pdp.people if p.id not in all_item_ids]
         self.pdp.events = [e for e in self.pdp.events if e.id not in all_item_ids]
         self.pdp.pair_bonds = [
@@ -702,6 +704,39 @@ class DiagramData:
             self._export_commit_state(item_ids, "post", id_mapping)
 
         return id_mapping
+
+    def _backfill_committed_parents(self) -> None:
+        """Cross-session parent back-fill: when a birth/adopted event names a
+        couple as the parents of an already-committed child whose `parents` is
+        still null, set it. The committed-data analogue of
+        pdp.infer_parents_from_birth_events, which only reaches delta people —
+        so a child committed in an earlier session is otherwise unreachable when
+        a later session states its parentage."""
+        bond_by_dyad: dict[tuple[int, int], int] = {}
+        for pb in self.pair_bonds:
+            a, b = pb.get("person_a"), pb.get("person_b")
+            if a is not None and b is not None:
+                bond_by_dyad[tuple(sorted((a, b)))] = pb["id"]
+        people_by_id = {p["id"]: p for p in self.people}
+        for e in self.events:
+            kind = e.get("kind")
+            kind = kind.value if isinstance(kind, EventKind) else kind
+            if kind not in (EventKind.Birth.value, EventKind.Adopted.value):
+                continue
+            person, spouse, child = e.get("person"), e.get("spouse"), e.get("child")
+            if person is None or spouse is None or child is None:
+                continue
+            bond_id = bond_by_dyad.get(tuple(sorted((person, spouse))))
+            if bond_id is None:
+                continue
+            ch = people_by_id.get(child)
+            if ch is None or ch.get("parents") is not None:
+                continue
+            ch["parents"] = bond_id
+            _log.info(
+                f"backfill_committed_parents: committed Person {child} "
+                f"parents={bond_id} from birth event {e.get('id')}"
+            )
 
     def _export_commit_state(
         self,

--- a/btcopilot/tests/personal/test_extract_full.py
+++ b/btcopilot/tests/personal/test_extract_full.py
@@ -183,3 +183,66 @@ def test_import_text_passes_text_as_conversation_history():
 
         pass1_prompt = mock_extract.call_args_list[0][0][0]
         assert text in pass1_prompt
+
+
+def test_gemini_structured_accepts_model_override():
+    # FD-337 regression: Pass-3 SARF review passes model=; the callee must accept it.
+    import inspect
+    from btcopilot.llmutil import gemini_structured
+
+    assert "model" in inspect.signature(gemini_structured).parameters
+
+
+def test_extract_full_windows_long_discussion_and_preserves_committed(discussion):
+    # FD-337: with WINDOW_SIZE forced below the statement count, extract_full runs one
+    # extraction per window on a clone and re-stages the union as negative-id deltas,
+    # without committing into the caller's diagram.
+    from btcopilot.pdp import extract_full
+
+    w1 = PDP(people=[Person(id=-1, name="Mom", gender="female", confidence=0.8)])
+    w2 = PDP(people=[Person(id=-1, name="Dad", gender="male", confidence=0.8)])
+
+    with patch("btcopilot.pdp.WINDOW_SIZE", 1), patch(
+        "btcopilot.pdp._two_pass_extract",
+        AsyncMock(side_effect=[(w1, PDPDeltas()), (w2, PDPDeltas())]),
+    ) as mock_two_pass:
+        diagram_data = DiagramData()
+        staged, _ = asyncio.run(extract_full(discussion, diagram_data))
+
+    assert mock_two_pass.call_count == 2
+    assert {p.name for p in staged.people} == {"Mom", "Dad"}
+    assert all(p.id < 0 for p in staged.people)
+    assert diagram_data.people == []
+
+
+def test_restage_new_items_keeps_committed_refs_positive():
+    # FD-337: re-staged new items get fresh negative ids; references into the original
+    # committed diagram stay positive, references among new items become negative.
+    import copy
+    from btcopilot.pdp import _restage_new_items
+
+    original = DiagramData(pdp=PDP(people=[Person(id=-1, name="User")]))
+    original.commit_pdp_items([-1])
+    user_id = original.people[0]["id"]
+
+    working = DiagramData(
+        people=copy.deepcopy(original.people),
+        lastItemId=original.lastItemId,
+    )
+    working.pdp = PDP(
+        people=[Person(id=-1, name="Spouse"), Person(id=-3, name="Kid", parents=-2)],
+        pair_bonds=[PairBond(id=-2, person_a=user_id, person_b=-1)],
+    )
+    working.commit_pdp_items([-1, -2, -3])
+
+    staged = _restage_new_items(working, original)
+
+    assert {p.name for p in staged.people} == {"Spouse", "Kid"}
+    assert all(p.id < 0 for p in staged.people)
+    assert len(staged.pair_bonds) == 1
+    bond = staged.pair_bonds[0]
+    assert bond.id < 0
+    assert user_id in (bond.person_a, bond.person_b)
+    assert any(x < 0 for x in (bond.person_a, bond.person_b))
+    kid = next(p for p in staged.people if p.name == "Kid")
+    assert kid.parents == bond.id

--- a/btcopilot/tests/schema/test_commit.py
+++ b/btcopilot/tests/schema/test_commit.py
@@ -614,3 +614,56 @@ def test_reject_transitive_cascade():
     assert data.pdp.people[0].name == "Bob"
     assert len(data.pdp.pair_bonds) == 0
     assert len(data.pdp.events) == 0
+
+
+def test_commit_backfills_committed_child_parents():
+    # FD-337: children + their couple committed in an earlier session, no parent links.
+    data = DiagramData(
+        pdp=PDP(
+            people=[
+                Person(id=-1, name="Anthony"),
+                Person(id=-2, name="Jim"),
+                Person(id=-3, name="Sheila"),
+            ],
+            pair_bonds=[PairBond(id=-4, person_a=-2, person_b=-3)],
+        )
+    )
+    m = data.commit_pdp_items([-1, -2, -3, -4])
+    anthony_id, jim_id, sheila_id, bond_id = m[-1], m[-2], m[-3], m[-4]
+    assert next(p for p in data.people if p["id"] == anthony_id)["parents"] is None
+
+    # A later session names the committed couple as Anthony's parents via a birth event.
+    data.pdp = PDP(
+        events=[
+            Event(
+                id=-5,
+                kind=EventKind.Birth,
+                person=jim_id,
+                spouse=sheila_id,
+                child=anthony_id,
+            )
+        ]
+    )
+    data.commit_pdp_items([-5])
+
+    assert next(p for p in data.people if p["id"] == anthony_id)["parents"] == bond_id
+
+
+def test_commit_backfill_does_not_overwrite_existing_parents():
+    data = DiagramData(
+        pdp=PDP(
+            people=[Person(id=-i, name=n) for i, n in enumerate(["Kid", "A", "B", "C", "D"], 1)],
+            pair_bonds=[
+                PairBond(id=-6, person_a=-2, person_b=-3),
+                PairBond(id=-7, person_a=-4, person_b=-5),
+            ],
+        )
+    )
+    m = data.commit_pdp_items([-1, -2, -3, -4, -5, -6, -7])
+    next(p for p in data.people if p["id"] == m[-1])["parents"] = m[-6]
+    # A later birth event names couple C+D as Kid's parents — must NOT overwrite A+B.
+    data.pdp = PDP(
+        events=[Event(id=-8, kind=EventKind.Birth, person=m[-4], spouse=m[-5], child=m[-1])]
+    )
+    data.commit_pdp_items([-8])
+    assert next(p for p in data.people if p["id"] == m[-1])["parents"] == m[-6]

--- a/btcopilot/training/connectivity_check.py
+++ b/btcopilot/training/connectivity_check.py
@@ -219,6 +219,7 @@ def _measure_accumulated_discussions(disc_ids: list[int]) -> dict:
         if disc is None:
             print(f"  Disc {disc_id}: NOT FOUND — skipping")
             continue
+        disc.extracted_through_order = None
         print(f"  Disc {disc_id} ({disc.summary or ''}, {len(disc.statements)} stmts)...", end=" ", flush=True)
         try:
             ai_pdp, _ = asyncio.run(pdp_mod.extract_full(disc, diagram_data))
@@ -271,6 +272,7 @@ def _dump_disconnected(disc_ids: list[int]) -> None:
         if disc is None:
             print(f"  Disc {disc_id}: NOT FOUND — skipping")
             continue
+        disc.extracted_through_order = None
         try:
             ai_pdp, _ = asyncio.run(pdp_mod.extract_full(disc, diagram_data))
         except Exception as e:

--- a/btcopilot/training/run_extract_full_f1.py
+++ b/btcopilot/training/run_extract_full_f1.py
@@ -72,6 +72,7 @@ def run_extract_full_f1(discussion_id=None, model=None, sarf_model=None):
 
     for disc_id in disc_ids:
         discussion = Discussion.query.get(disc_id)
+        discussion.extracted_through_order = None
         print(f"Disc {disc_id} ({discussion.summary})...", end=" ", flush=True)
         disc_start = time.time()
 
@@ -146,7 +147,10 @@ def run_extract_full_f1(discussion_id=None, model=None, sarf_model=None):
             "people_f1": people_f1_metrics.f1,
             "events_f1": events_f1_metrics.f1,
             "pair_bonds_f1": bonds_f1_metrics.f1,
+            "pair_bonds_precision": bonds_f1_metrics.precision,
+            "pair_bonds_recall": bonds_f1_metrics.recall,
             "child_of_f1": child_of_f1_metrics.f1,
+            "child_of_precision": child_of_f1_metrics.precision,
             "child_of_recall": child_of_f1_metrics.recall,
             "child_of_tp": child_of_f1_metrics.tp,
             "child_of_fp": child_of_f1_metrics.fp,
@@ -186,7 +190,10 @@ def run_extract_full_f1(discussion_id=None, model=None, sarf_model=None):
     avg_people = sum(r["people_f1"] for r in results) / n
     avg_events = sum(r["events_f1"] for r in results) / n
     avg_bonds = sum(r["pair_bonds_f1"] for r in results) / n
+    avg_bonds_precision = sum(r["pair_bonds_precision"] for r in results) / n
+    avg_bonds_recall = sum(r["pair_bonds_recall"] for r in results) / n
     avg_child_of = sum(r["child_of_f1"] for r in results) / n
+    avg_child_of_precision = sum(r["child_of_precision"] for r in results) / n
     avg_child_of_recall = sum(r["child_of_recall"] for r in results) / n
     avg_aggregate = sum(r["aggregate_f1"] for r in results) / n
 
@@ -196,8 +203,8 @@ def run_extract_full_f1(discussion_id=None, model=None, sarf_model=None):
     print("=" * 60)
     print(f"People F1:      {avg_people:.3f}  (target > 0.7)")
     print(f"Events F1:      {avg_events:.3f}  (target > 0.3)")
-    print(f"PairBonds F1:   {avg_bonds:.3f}")
-    print(f"ParentChild F1: {avg_child_of:.3f}  recall={avg_child_of_recall:.3f}  (under-extraction signal)")
+    print(f"PairBonds F1:   {avg_bonds:.3f}  precision={avg_bonds_precision:.3f}  recall={avg_bonds_recall:.3f}")
+    print(f"ParentChild F1: {avg_child_of:.3f}  precision={avg_child_of_precision:.3f}  recall={avg_child_of_recall:.3f}  (precision=spurious-link, recall=under-extraction)")
     print(f"Aggregate F1:   {avg_aggregate:.3f}")
     print()
 
@@ -212,9 +219,13 @@ def run_extract_full_f1(discussion_id=None, model=None, sarf_model=None):
             f"    Events:    F1={r['events_f1']:.3f}  "
             f"(AI:{r['ai_events']} GT:{r['gt_events']} TP:{r['events_tp']} FP:{r['events_fp']} FN:{r['events_fn']})"
         )
-        print(f"    PairBonds: F1={r['pair_bonds_f1']:.3f}")
         print(
-            f"    ParentChild: F1={r['child_of_f1']:.3f} recall={r['child_of_recall']:.3f} "
+            f"    PairBonds: F1={r['pair_bonds_f1']:.3f} "
+            f"precision={r['pair_bonds_precision']:.3f} recall={r['pair_bonds_recall']:.3f}"
+        )
+        print(
+            f"    ParentChild: F1={r['child_of_f1']:.3f} "
+            f"precision={r['child_of_precision']:.3f} recall={r['child_of_recall']:.3f} "
             f"(TP:{r['child_of_tp']} FP:{r['child_of_fp']} FN:{r['child_of_fn']})"
         )
         if r["sarf"]:
@@ -242,6 +253,9 @@ def run_extract_full_f1(discussion_id=None, model=None, sarf_model=None):
         "people_f1": avg_people,
         "events_f1": avg_events,
         "pair_bonds_f1": avg_bonds,
+        "pair_bonds_precision": avg_bonds_precision,
+        "child_of_f1": avg_child_of,
+        "child_of_precision": avg_child_of_precision,
         "aggregate_f1": avg_aggregate,
         "per_discussion": results,
     }


### PR DESCRIPTION
## FD-337: Re-extraction for long/multi-session conversations

### Corrected diagnosis (the ticket's "stuck at 25-30%" was a measurement bug)
The from-empty `connectivity_check --accumulate` honored each discussion's persisted re-extraction cursor. Diagram 1924's discussions carry a stale "accepted through order 200" cursor, so the from-empty accumulate extracted an *empty tail* and the model produced a degenerate fragment → the ~25-30% figure. It was never the extraction that was stuck; it was the measurement.

**The real defect is still real:** the actual stored diagram 1924 is **32 people in 14 components — 56% connected.** Production's incremental extraction (with the Pass-3 crash below live) left it fragmented.

### What this PR does
- **Crash fix (`llmutil.gemini_structured`)** — accepts optional `model=`. A pre-existing regression (FD-333, c8d5c00) crashed **every extraction reaching Pass 3 (SARF review)** with `TypeError`. ⚠️ If master is deployed, production chat extraction has been crashing since May 21 — please confirm deploy state.
- **Windowing (`pdp.extract_full`)** — conversations > `WINDOW_SIZE` (default 80, env `FD_WINDOW_SIZE`) are extracted in windows on a *clone*, each window committed so later windows see it as context, then re-staged as negative-id deltas. Short spans keep the single-shot path byte-for-byte. Contract preserved — never commits into the caller's diagram (verified by test).
- **Cross-session parent back-fill (`schema.commit_pdp_items`)** — sets `parents` on an already-committed child when a later session emits a birth event naming its couple.
- **Measurement fidelity** — `connectivity_check`/`run_extract_full_f1` null the persisted cursor for from-empty measurement; F1 runner now prints PairBonds + ParentChild **precision**.
- **Tests** — back-fill (+ no-overwrite guard), windowing contract, ID-remap reconstruction, model-override regression guard. 264 passing in the changed areas; CI green.

### Honest attribution (accumulate 55,58,60, real implementation)
| config | LCC | people | note |
|---|---|---|---|
| stale cursor (the old "baseline") | ~35% | ~18 | degenerate measurement |
| **cursor fix only**, single-shot | ~81% median | ~22 | dominant lever; drops ~10 family members |
| + back-fill | ~82% | ~22 | back-fill ≈ +1% |
| **+ windowing** (the deliverable) | **80.0% median** (15 runs) | **~31** | full family; see distribution below |

**Windowing earns its place on completeness:** single-shot recovers only ~22 of 32 people; windowing recovers ~31. LCC% is a ratio that hides this — the denominator grows with completeness.

### Acceptance status — borderline, stated plainly
15-run windowed distribution: `53, 69, 75, 77, 77, 78, 80, 80, 81, 83, 83, 84, 84, 84, 90`.
- **median 80.0%** (right at the AC line), **mean 78.6%**, **9/15 ≥80%**, floor tail 53-69%.
- Full family recovered (~31 of 32 people) — vs the stored diagram's fragmented 56%.

So the AC's ≥80% is **met on the median only**; the mean is just under and the floor is not uniformly ≥80%.

### Floor limitation (why it isn't higher) — and the ceiling
The sub-80 runs drop a real family member's *bridge* — e.g. the proband's sibling's spouse (Vance+Meredith) extracted as a free-floating couple, or Jim+Sheila's family correctly internally-linked but not joined to the proband. These are missing relationship links the model omits run-to-run. The obvious levers are **ruled out by the ticket**: proband-linking prompt directives (tried, caused dangling-reference crashes), name-matching dedup (forbidden), extra structural-completion passes (tried, regressed F1).

**The bridges exist — they're variance-distributed.** A 6-run consensus experiment (merge the union of repeated windowed extractions) reaches **94.9%** connectivity (plain LCC) vs a single-run median of ~84% — each run misses a different subset of bridges, and the union recovers nearly all of them. So the floor is **achievable via multi-sample consensus at ~K× extraction cost** — viable as an async "deep re-extraction," not real-time. That's a product decision (is K× latency acceptable for a high-fidelity re-extraction mode?), so it's **not in this PR**. This confirms the floor is a model-variance limitation, not a code gap.

### No F1 regression
Aggregate ~0.65, ParentChild F1 ~0.80 (precision reported), People ~0.93. On baseline.

Companion: fdserver#24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
