### PR TITLE
Route coach sessions to fdserver; document btcopilot-sources purpose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,16 @@ Backend for Pro/Personal apps, training app, AI extraction system.
 
 ## Confidential Data Rules
 
-Induction reports and GT exports contain clinical data, and extraction/conversational-AI
-experiment artifacts are proprietary IP — **NEVER store either in the btcopilot repo, and
-NEVER in btcopilot-sources**. All of it lives in the private **fdserver** repo (2026-07-22,
-Patrick's direction; supersedes the earlier btcopilot-sources scheme).
+Induction reports, GT exports, and coach sessions contain clinical data, and
+extraction/conversational-AI experiment artifacts are proprietary IP — **NEVER store any
+of it in the btcopilot repo, and NEVER in btcopilot-sources**. All of it lives in the
+private **fdserver** repo (2026-07-22, Patrick's direction; supersedes the earlier
+btcopilot-sources scheme).
+
+**btcopilot-sources is ONLY for copyrighted academic literature** (Bowen theory book
+chapters etc.; rarely added to). It will be retired once the Pro app's Copilot feature is
+replaced by the embedded personal app. Never route generated data or experiment artifacts
+there.
 
 | Data Type | WRONG Location | Correct Location |
 |-----------|----------------|-----------------|

--- a/bin/coach_chat.py
+++ b/bin/coach_chat.py
@@ -64,15 +64,15 @@ try:
 except ImportError:
     Mail = None
 
-# Artifact roots. DEFAULT is the private sibling repo (btcopilot-sources/),
-# OUTSIDE the open-source tree — same rule as induction reports / GT exports
-# (see btcopilot/CLAUDE.md confidential-data table). Freeform sessions draw
+# Artifact roots. DEFAULT is the private sibling repo (fdserver/), OUTSIDE the
+# open-source tree — same rule as induction reports / GT exports (see
+# btcopilot/CLAUDE.md confidential-data table). Freeform sessions draw
 # on real personal/family content; that must never sit inside the OSS repo,
 # gitignored or not. The in-repo path is opt-in (--out shared) and only for
 # synthetic-persona runs safe to share.
 _PRIVATE_DIR = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..",
-                 "btcopilot-sources", "coach-sessions")
+                 "fdserver", "coach-sessions")
 )
 _SHARED_DIR = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "doc", "log", "coach-sessions")
@@ -266,7 +266,7 @@ def main():
     ap.add_argument("--persona", choices=["none", *PERSONAS], default="none")
     ap.add_argument(
         "--out", choices=["private", "shared"], default="private",
-        help="private = btcopilot-sources/ (default, never in OSS repo); "
+        help="private = fdserver/coach-sessions/ (default, never in OSS repo); "
         "shared = in-repo doc/log (synthetic personas only, no real data)",
     )
     ap.add_argument(


### PR DESCRIPTION
Follow-up to #128. btcopilot-sources is only for copyrighted academic literature (rare additions; slated for retirement once the Pro app Copilot feature is replaced by the embedded personal app) — coach sessions never belonged there.

- `bin/coach_chat.py` private output root → sibling `fdserver/coach-sessions/` (default `--out private` behavior; help text updated)
- CLAUDE.md confidential-data section now states the sources-repo purpose explicitly

Companion fdserver PR moves the 16 existing session files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)